### PR TITLE
Add label shortcodes, statoids, etc

### DIFF
--- a/data/856/327/89/85632789.geojson
+++ b/data/856/327/89/85632789.geojson
@@ -15,6 +15,9 @@
     "itu:country_code":[
         "358"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AX"
+    ],
     "lbl:latitude":60.15205,
     "lbl:longitude":20.291594,
     "mps:latitude":60.15205,
@@ -745,7 +748,7 @@
     "wof:lang":[
         "swe"
     ],
-    "wof:lastmodified":1563282669,
+    "wof:lastmodified":1565709933,
     "wof:name":"Aland",
     "wof:parent_id":136253047,
     "wof:placetype":"dependency",

--- a/data/856/331/43/85633143.geojson
+++ b/data/856/331/43/85633143.geojson
@@ -14,6 +14,9 @@
     "itu:country_code":[
         "358"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "FI"
+    ],
     "lbl:latitude":63.252357,
     "lbl:longitude":27.276469,
     "mps:latitude":63.252357,
@@ -1244,9 +1247,6 @@
         }
     ],
     "wof:id":85633143,
-    "wof:lang":[
-        "fin"
-    ],
     "wof:lang_x_official":[
         "fin",
         "swe"
@@ -1255,7 +1255,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282627,
+    "wof:lastmodified":1565709931,
     "wof:name":"Finland",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/830/67/85683067.geojson
+++ b/data/856/830/67/85683067.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Uusimaa Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "US"
+    ],
     "lbl:latitude":60.276941,
     "lbl:longitude":24.790343,
     "mps:latitude":60.280446,
@@ -332,6 +335,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"9,131",
+    "statoids:area_mi":"3,526",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Helsinki",
+    "statoids:country":"FI",
+    "statoids:gec":"FI35",
+    "statoids:hasc":"FI.US",
+    "statoids:iso":"18",
+    "statoids:population":"1,501,511",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-18",
     "wd:wordcount":878,
     "wof:belongsto":[
@@ -345,7 +361,7 @@
         "fips:code":"",
         "gn:id":830709,
         "gp:id":29389247,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.US",
         "unlc:id":"FI-18",
         "wd:id":"Q5711"
     },
@@ -369,11 +385,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282657,
+    "wof:lastmodified":1565823294,
     "wof:name":"Uusimaa",
     "wof:parent_id":404227411,
     "wof:placetype":"region",
+    "wof:population":1501511,
+    "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"US",
     "wof:subdivision":"FI-18",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/830/73/85683073.geojson
+++ b/data/856/830/73/85683073.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Southwest Finland Region"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SF"
+    ],
     "lbl:latitude":60.2014,
     "lbl:longitude":22.011269,
     "mps:latitude":60.204152,
@@ -299,6 +302,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"10,663",
+    "statoids:area_mi":"4,117",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Turku",
+    "statoids:country":"FI",
+    "statoids:gec":"FI34",
+    "statoids:hasc":"FI.SF",
+    "statoids:iso":"19",
+    "statoids:population":"461,177",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-19",
     "wd:wordcount":778,
     "wof:belongsto":[
@@ -312,7 +328,7 @@
         "fips:code":"",
         "gn:id":830708,
         "gp:id":29389250,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.SF",
         "unlc:id":"FI-19",
         "wd:id":"Q5712"
     },
@@ -336,11 +352,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282658,
+    "wof:lastmodified":1565823295,
     "wof:name":"Southwest Finland",
     "wof:parent_id":404227405,
     "wof:placetype":"region",
+    "wof:population":461177,
+    "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"SF",
     "wof:subdivision":"FI-19",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/830/77/85683077.geojson
+++ b/data/856/830/77/85683077.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Tavastia Proper Region"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KH"
+    ],
     "lbl:latitude":60.908442,
     "lbl:longitude":24.414319,
     "mps:latitude":60.909474,
@@ -303,6 +306,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"5,200",
+    "statoids:area_mi":"2,008",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"H\u00e4meenlinna",
+    "statoids:country":"FI",
+    "statoids:gec":"FI20",
+    "statoids:hasc":"FI.KH",
+    "statoids:iso":"06",
+    "statoids:population":"173,041",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-06",
     "wd:wordcount":352,
     "wof:belongsto":[
@@ -316,7 +332,7 @@
         "fips:code":"",
         "gn:id":830705,
         "gp:id":29389249,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.KH",
         "unlc:id":"FI-06",
         "wd:id":"Q5695"
     },
@@ -340,11 +356,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282667,
+    "wof:lastmodified":1565823299,
     "wof:name":"Tavastia Proper",
     "wof:parent_id":404227411,
     "wof:placetype":"region",
+    "wof:population":173041,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"KH",
     "wof:subdivision":"FI-06",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/830/81/85683081.geojson
+++ b/data/856/830/81/85683081.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Kymenlaakso Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KY"
+    ],
     "lbl:latitude":60.598743,
     "lbl:longitude":26.94614,
     "mps:latitude":60.598003,
@@ -285,6 +288,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"5,112",
+    "statoids:area_mi":"1,974",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Kotka",
+    "statoids:country":"FI",
+    "statoids:gec":"FI25",
+    "statoids:hasc":"FI.KY",
+    "statoids:iso":"09",
+    "statoids:population":"182,754",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-09",
     "wd:wordcount":345,
     "wof:belongsto":[
@@ -298,7 +314,7 @@
         "fips:code":"",
         "gn:id":830703,
         "gp:id":-29389251,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.KY",
         "unlc:id":"FI-09",
         "wd:id":"Q5698"
     },
@@ -322,11 +338,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282660,
+    "wof:lastmodified":1565823295,
     "wof:name":"Kymenlaakso",
     "wof:parent_id":404227411,
     "wof:placetype":"region",
+    "wof:population":182754,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"KY",
     "wof:subdivision":"FI-09",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/830/91/85683091.geojson
+++ b/data/856/830/91/85683091.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Paijanne Tavastia Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "PH"
+    ],
     "lbl:latitude":61.207691,
     "lbl:longitude":25.690159,
     "mps:latitude":61.20953,
@@ -233,6 +236,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"5,127",
+    "statoids:area_mi":"1,979",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Lahti",
+    "statoids:country":"FI",
+    "statoids:gec":"FI27",
+    "statoids:hasc":"FI.PH",
+    "statoids:iso":"16",
+    "statoids:population":"200,847",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "wd:wordcount":322,
     "wof:belongsto":[
         102191581,
@@ -243,6 +259,7 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29389255,
+        "hasc:id":"FI.PH",
         "wd:id":"Q5708"
     },
     "wof:country":"FI",
@@ -265,11 +282,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282662,
+    "wof:lastmodified":1565823297,
     "wof:name":"Paijanne Tavastia",
     "wof:parent_id":404227411,
     "wof:placetype":"region",
+    "wof:population":200847,
+    "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"PH",
     "wof:superseded_by":[],
     "wof:supersedes":[
         85683085

--- a/data/856/830/95/85683095.geojson
+++ b/data/856/830/95/85683095.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Satakunta Region"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SA"
+    ],
     "lbl:latitude":61.522116,
     "lbl:longitude":21.785369,
     "mps:latitude":61.52143,
@@ -307,6 +310,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"7,957",
+    "statoids:area_mi":"3,072",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Pori",
+    "statoids:country":"FI",
+    "statoids:gec":"FI32",
+    "statoids:hasc":"FI.SA",
+    "statoids:iso":"17",
+    "statoids:population":"227,652",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-17",
     "wd:wordcount":1273,
     "wof:belongsto":[
@@ -320,7 +336,7 @@
         "fips:code":"",
         "gn:id":831041,
         "gp:id":29389252,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.SA",
         "unlc:id":"FI-17",
         "wd:id":"Q5709"
     },
@@ -344,11 +360,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282655,
+    "wof:lastmodified":1565823293,
     "wof:name":"Satakunta",
     "wof:parent_id":404227405,
     "wof:placetype":"region",
+    "wof:population":227652,
+    "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"SA",
     "wof:subdivision":"FI-17",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/830/99/85683099.geojson
+++ b/data/856/830/99/85683099.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Pirkanmaa Region"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "TR"
+    ],
     "lbl:latitude":61.708766,
     "lbl:longitude":23.673573,
     "mps:latitude":61.711602,
@@ -308,6 +311,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"12,447",
+    "statoids:area_mi":"4,806",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Tampere",
+    "statoids:country":"FI",
+    "statoids:gec":"FI28",
+    "statoids:hasc":"FI.TR",
+    "statoids:iso":"11",
+    "statoids:population":"480,705",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-11",
     "wd:wordcount":352,
     "wof:belongsto":[
@@ -321,7 +337,7 @@
         "fips:code":"",
         "gn:id":830704,
         "gp:id":29389248,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.TR",
         "unlc:id":"FI-11",
         "wd:id":"Q5701"
     },
@@ -345,11 +361,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282665,
+    "wof:lastmodified":1565823298,
     "wof:name":"Pirkanmaa",
     "wof:parent_id":404227417,
     "wof:placetype":"region",
+    "wof:population":480705,
+    "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"TR",
     "wof:subdivision":"FI-11",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/03/85683103.geojson
+++ b/data/856/831/03/85683103.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "South Karelia Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SK"
+    ],
     "lbl:latitude":61.013798,
     "lbl:longitude":28.00138,
     "mps:latitude":61.071615,
@@ -310,6 +313,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"5,613",
+    "statoids:area_mi":"2,167",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Lapeenranta",
+    "statoids:country":"FI",
+    "statoids:gec":"FI17",
+    "statoids:hasc":"FI.SK",
+    "statoids:iso":"02",
+    "statoids:population":"134,448",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-02",
     "wd:wordcount":1296,
     "wof:belongsto":[
@@ -323,7 +339,7 @@
         "fips:code":"",
         "gn:id":830699,
         "gp:id":29389253,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.SK",
         "unlc:id":"FI-02",
         "wd:id":"Q5691"
     },
@@ -347,11 +363,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282630,
+    "wof:lastmodified":1565823283,
     "wof:name":"South Karelia",
     "wof:parent_id":404227411,
     "wof:placetype":"region",
+    "wof:population":134448,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"SK",
     "wof:subdivision":"FI-02",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/09/85683109.geojson
+++ b/data/856/831/09/85683109.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Southern Savonia Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SS"
+    ],
     "lbl:latitude":61.859012,
     "lbl:longitude":27.362508,
     "mps:latitude":61.819144,
@@ -284,6 +287,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"13,986",
+    "statoids:area_mi":"5,400",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Mikkeli",
+    "statoids:country":"FI",
+    "statoids:gec":"FI19",
+    "statoids:hasc":"FI.SS",
+    "statoids:iso":"04",
+    "statoids:population":"156,632",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-04",
     "wd:wordcount":262,
     "wof:belongsto":[
@@ -297,7 +313,7 @@
         "fips:code":"",
         "gn:id":830695,
         "gp:id":29389260,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.SS",
         "unlc:id":"FI-04",
         "wd:id":"Q5693"
     },
@@ -321,11 +337,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282640,
+    "wof:lastmodified":1565823287,
     "wof:name":"Southern Savonia",
     "wof:parent_id":404227407,
     "wof:placetype":"region",
+    "wof:population":156632,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"SS",
     "wof:subdivision":"FI-04",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/13/85683113.geojson
+++ b/data/856/831/13/85683113.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Southern Ostrobothnia Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SO"
+    ],
     "lbl:latitude":62.837066,
     "lbl:longitude":23.078909,
     "mps:latitude":62.851437,
@@ -299,6 +302,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"13,444",
+    "statoids:area_mi":"5,191",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Sein\u00e4joki",
+    "statoids:country":"FI",
+    "statoids:gec":"FI18",
+    "statoids:hasc":"FI.SO",
+    "statoids:iso":"03",
+    "statoids:population":"193,511",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-03",
     "wd:wordcount":257,
     "wof:belongsto":[
@@ -312,7 +328,7 @@
         "fips:code":"",
         "gn:id":830682,
         "gp:id":29389256,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.SO",
         "unlc:id":"FI-03",
         "wd:id":"Q5692"
     },
@@ -336,11 +352,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282651,
+    "wof:lastmodified":1565823292,
     "wof:name":"Southern Ostrobothnia",
     "wof:parent_id":404227417,
     "wof:placetype":"region",
+    "wof:population":193511,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"SO",
     "wof:subdivision":"FI-03",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/17/85683117.geojson
+++ b/data/856/831/17/85683117.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Central Finland Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "CF"
+    ],
     "lbl:latitude":62.460613,
     "lbl:longitude":25.403161,
     "mps:latitude":62.460653,
@@ -297,6 +300,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"16,707",
+    "statoids:area_mi":"6,450",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Jyv\u00e4skyl\u00e4",
+    "statoids:country":"FI",
+    "statoids:gec":"FI24",
+    "statoids:hasc":"FI.CF",
+    "statoids:iso":"08",
+    "statoids:population":"271,747",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "wd:wordcount":264,
     "wof:belongsto":[
         102191581,
@@ -309,7 +325,7 @@
         "fips:code":"",
         "gn:id":830685,
         "gp:id":29389258,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.CF",
         "wd:id":"Q5697"
     },
     "wof:country":"FI",
@@ -332,11 +348,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282634,
+    "wof:lastmodified":1565823285,
     "wof:name":"Central Finland",
     "wof:parent_id":404227417,
     "wof:placetype":"region",
+    "wof:population":271747,
+    "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"CF",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]

--- a/data/856/831/19/85683119.geojson
+++ b/data/856/831/19/85683119.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Ostrobothnia Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "OS"
+    ],
     "lbl:latitude":62.906168,
     "lbl:longitude":21.073023,
     "mps:latitude":62.902204,
@@ -270,6 +273,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"7,749",
+    "statoids:area_mi":"2,992",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Vaasa",
+    "statoids:country":"FI",
+    "statoids:gec":"FI29",
+    "statoids:hasc":"FI.OS",
+    "statoids:iso":"12",
+    "statoids:population":"175,985",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "wd:wordcount":46,
     "wof:belongsto":[
         102191581,
@@ -282,7 +298,7 @@
         "fips:code":"",
         "gn:id":830676,
         "gp:id":29389259,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.OS",
         "wd:id":"Q5702"
     },
     "wof:country":"FI",
@@ -305,11 +321,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282636,
+    "wof:lastmodified":1565823286,
     "wof:name":"Ostrobothnia",
     "wof:parent_id":404227417,
     "wof:placetype":"region",
+    "wof:population":175985,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"OS",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]

--- a/data/856/831/25/85683125.geojson
+++ b/data/856/831/25/85683125.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Central Ostrobothnia Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "CO"
+    ],
     "lbl:latitude":63.569551,
     "lbl:longitude":24.186836,
     "mps:latitude":63.569406,
@@ -303,6 +306,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"5,273",
+    "statoids:area_mi":"2,036",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Kokkola",
+    "statoids:country":"FI",
+    "statoids:gec":"FI23",
+    "statoids:hasc":"FI.CO",
+    "statoids:iso":"07",
+    "statoids:population":"71,029",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-07",
     "wd:wordcount":178,
     "wof:belongsto":[
@@ -316,7 +332,7 @@
         "fips:code":"",
         "gn:id":830675,
         "gp:id":29389257,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.CO",
         "unlc:id":"FI-07",
         "wd:id":"Q5696"
     },
@@ -340,11 +356,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282653,
+    "wof:lastmodified":1565823293,
     "wof:name":"Central Ostrobothnia",
     "wof:parent_id":404227417,
     "wof:placetype":"region",
+    "wof:population":71029,
+    "wof:population_rank":8,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"CO",
     "wof:subdivision":"FI-07",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/31/85683131.geojson
+++ b/data/856/831/31/85683131.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Northern Savonia Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NS"
+    ],
     "lbl:latitude":63.20821,
     "lbl:longitude":27.509305,
     "mps:latitude":63.207416,
@@ -312,6 +315,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"16,771",
+    "statoids:area_mi":"6,475",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Kuopio",
+    "statoids:country":"FI",
+    "statoids:gec":"FI33",
+    "statoids:hasc":"FI.NS",
+    "statoids:iso":"15",
+    "statoids:population":"248,423",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-15",
     "wd:wordcount":296,
     "wof:belongsto":[
@@ -325,7 +341,7 @@
         "fips:code":"",
         "gn:id":830690,
         "gp:id":29389262,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.NS",
         "unlc:id":"FI-15",
         "wd:id":"Q5706"
     },
@@ -349,11 +365,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282644,
+    "wof:lastmodified":1565823289,
     "wof:name":"Northern Savonia",
     "wof:parent_id":404227407,
     "wof:placetype":"region",
+    "wof:population":248423,
+    "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"NS",
     "wof:subdivision":"FI-15",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/33/85683133.geojson
+++ b/data/856/831/33/85683133.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "North Karelen Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NK"
+    ],
     "lbl:latitude":62.780693,
     "lbl:longitude":30.049511,
     "mps:latitude":62.779431,
@@ -313,6 +316,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"17,763",
+    "statoids:area_mi":"6,858",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Joensuu",
+    "statoids:country":"FI",
+    "statoids:gec":"FI30",
+    "statoids:hasc":"FI.NK",
+    "statoids:iso":"13",
+    "statoids:population":"166,129",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-13",
     "wd:wordcount":760,
     "wof:belongsto":[
@@ -326,7 +342,7 @@
         "fips:code":"",
         "gn:id":830686,
         "gp:id":29389261,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.NK",
         "unlc:id":"FI-13",
         "wd:id":"Q5703"
     },
@@ -350,11 +366,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282632,
+    "wof:lastmodified":1565823284,
     "wof:name":"North Karelen",
     "wof:parent_id":404227407,
     "wof:placetype":"region",
+    "wof:population":166129,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"NK",
     "wof:subdivision":"FI-13",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/37/85683137.geojson
+++ b/data/856/831/37/85683137.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Kainuu Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KA"
+    ],
     "lbl:latitude":64.642133,
     "lbl:longitude":28.939827,
     "mps:latitude":64.577614,
@@ -310,6 +313,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"21,504",
+    "statoids:area_mi":"8,303",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Kajaani",
+    "statoids:country":"FI",
+    "statoids:gec":"FI22",
+    "statoids:hasc":"FI.KA",
+    "statoids:iso":"05",
+    "statoids:population":"83,160",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-05",
     "wd:wordcount":4437,
     "wof:belongsto":[
@@ -323,7 +339,7 @@
         "fips:code":"",
         "gn:id":830664,
         "gp:id":29389264,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.KA",
         "unlc:id":"FI-05",
         "wd:id":"Q5694"
     },
@@ -347,11 +363,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282647,
+    "wof:lastmodified":1565823290,
     "wof:name":"Kainuu",
     "wof:parent_id":404227415,
     "wof:placetype":"region",
+    "wof:population":83160,
+    "wof:population_rank":8,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"KA",
     "wof:subdivision":"FI-05",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/43/85683143.geojson
+++ b/data/856/831/43/85683143.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Northern Ostrobothnia Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NO"
+    ],
     "lbl:latitude":64.631833,
     "lbl:longitude":25.612497,
     "mps:latitude":64.645731,
@@ -314,6 +317,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"35,236",
+    "statoids:area_mi":"13,605",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Oulu",
+    "statoids:country":"FI",
+    "statoids:gec":"FI31",
+    "statoids:hasc":"FI.NO",
+    "statoids:iso":"14",
+    "statoids:population":"386,144",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-14",
     "wd:wordcount":234,
     "wof:belongsto":[
@@ -327,7 +343,7 @@
         "fips:code":"",
         "gn:id":830667,
         "gp:id":29389265,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.NO",
         "unlc:id":"FI-14",
         "wd:id":"Q5704"
     },
@@ -351,11 +367,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282638,
+    "wof:lastmodified":1565823286,
     "wof:name":"Northern Ostrobothnia",
     "wof:parent_id":404227415,
     "wof:placetype":"region",
+    "wof:population":386144,
+    "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"NO",
     "wof:subdivision":"FI-14",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/831/47/85683147.geojson
+++ b/data/856/831/47/85683147.geojson
@@ -13,6 +13,9 @@
     "label:eng_x_preferred_longname":[
         "Lapland Province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "LA"
+    ],
     "lbl:latitude":67.613744,
     "lbl:longitude":26.765912,
     "mps:latitude":67.616229,
@@ -300,6 +303,19 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl:centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_date":"2008-12-31",
+    "statoids:area_km":"92,664",
+    "statoids:area_mi":"35,778",
+    "statoids:as_of_date":"2008-12-31",
+    "statoids:capital":"Rovaniemi",
+    "statoids:country":"FI",
+    "statoids:gec":"FI26",
+    "statoids:hasc":"FI.LA",
+    "statoids:iso":"10",
+    "statoids:population":"183,963",
+    "statoids:timezone":"+2~",
+    "statoids:type":"region",
     "unlc:subdivision":"FI-10",
     "wd:wordcount":183,
     "wof:belongsto":[
@@ -313,7 +329,7 @@
         "fips:code":"",
         "gn:id":830603,
         "gp:id":12577870,
-        "hasc:id":"FI.",
+        "hasc:id":"FI.LA",
         "unlc:id":"FI-10",
         "wd:id":"Q5700"
     },
@@ -337,11 +353,14 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1563282648,
+    "wof:lastmodified":1565823291,
     "wof:name":"Lapland",
     "wof:parent_id":404227409,
     "wof:placetype":"region",
+    "wof:population":183963,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-fi",
+    "wof:shortcode":"LA",
     "wof:subdivision":"FI-10",
     "wof:superseded_by":[],
     "wof:supersedes":[],


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/900
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1689

Region records in Finland did not have shortcodes, this PR adds them.
When QAing this placetype, I realized the region records were also missing statoids properties, as well as population data. This PR adds those properties in, too.