### PR TITLE
Update place Lehtisaari

### DIFF
--- a/data/110/872/710/1/1108727101.geojson
+++ b/data/110/872/710/1/1108727101.geojson
@@ -44,7 +44,7 @@
     "src:geom_alt":[],
     "wof:belongsto":[
         102191581,
-        890537261,
+        890537235,
         907199715,
         85633143,
         101748417,
@@ -68,7 +68,7 @@
             "empire_id":136253047,
             "localadmin_id":907199715,
             "locality_id":101748417,
-            "macrohood_id":890537261,
+            "macrohood_id":890537235,
             "neighbourhood_id":1108727101,
             "region_id":85683067
         }
@@ -76,7 +76,7 @@
     "wof:id":1108727101,
     "wof:lastmodified":1566595015,
     "wof:name":"Lehtisaari",
-    "wof:parent_id":890537261,
+    "wof:parent_id":890537235,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-fi",
     "wof:superseded_by":[],


### PR DESCRIPTION
Lehtisaari belongs to the Munkkiniemi (890537235) macrohood, not to Lauttasaari (890537261)