### PR TITLE
FI concordances, placetype local, and more

### DIFF
--- a/data/115/932/148/3/1159321483.geojson
+++ b/data/115/932/148/3/1159321483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.044313,
-    "geom:area_square_m":6218693811.60078,
+    "geom:area_square_m":6218693811.599284,
     "geom:bbox":"24.8554903367,60.6714762655,26.5136626338,61.8014078798",
     "geom:latitude":61.211064,
     "geom:longitude":25.702831,
@@ -255,7 +255,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415345,
-    "wof:geomhash":"ae3e6220b2a27402bd8696a62eb22550",
+    "wof:geomhash":"1d24f4df00feb150c5495de1e2e00720",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -267,7 +267,7 @@
         }
     ],
     "wof:id":1159321483,
-    "wof:lastmodified":1566595579,
+    "wof:lastmodified":1695886732,
     "wof:name":"Lahti",
     "wof:parent_id":85683091,
     "wof:placetype":"county",

--- a/data/115/932/148/5/1159321485.geojson
+++ b/data/115/932/148/5/1159321485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.54665,
-    "geom:area_square_m":3162407285.218939,
+    "geom:area_square_m":3162407467.62822,
     "geom:bbox":"23.206522,61.715538,24.730913,62.494334",
     "geom:latitude":62.104963,
     "geom:longitude":24.017373,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415351,
-    "wof:geomhash":"0d260001f87929fba50be51b44d0ce1d",
+    "wof:geomhash":"9110d81a3cf4e9d74dd9720719570bf4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321485,
-    "wof:lastmodified":1627522119,
+    "wof:lastmodified":1695886589,
     "wof:name":"Yla-Pirkanmaa",
     "wof:parent_id":85683099,
     "wof:placetype":"county",

--- a/data/115/932/148/7/1159321487.geojson
+++ b/data/115/932/148/7/1159321487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.668106,
-    "geom:area_square_m":8959792393.124733,
+    "geom:area_square_m":8959792393.124744,
     "geom:bbox":"26.2911059544,63.6688114762,29.2110310565,64.8352873766",
     "geom:latitude":64.253703,
     "geom:longitude":27.793559,
@@ -192,7 +192,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415352,
-    "wof:geomhash":"552e9191c01f6a79db3a1b5dcb08a5f3",
+    "wof:geomhash":"9df87e64ad20d968d6a01ebe4250bb22",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -204,7 +204,7 @@
         }
     ],
     "wof:id":1159321487,
-    "wof:lastmodified":1566595578,
+    "wof:lastmodified":1695886731,
     "wof:name":"Kajaani",
     "wof:parent_id":85683137,
     "wof:placetype":"county",

--- a/data/115/932/148/9/1159321489.geojson
+++ b/data/115/932/148/9/1159321489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.66077,
-    "geom:area_square_m":8403540953.50947,
+    "geom:area_square_m":8403541564.455125,
     "geom:bbox":"27.71254,65.250349,30.138463,66.485853",
     "geom:latitude":65.84408,
     "geom:longitude":28.98879,
@@ -72,7 +72,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415352,
-    "wof:geomhash":"8cc42e724382e8949121ebc3f9aa989a",
+    "wof:geomhash":"51732821af112313856895226fe7d3bd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -84,7 +84,7 @@
         }
     ],
     "wof:id":1159321489,
-    "wof:lastmodified":1627522124,
+    "wof:lastmodified":1695886598,
     "wof:name":"Koillismaa",
     "wof:parent_id":85683143,
     "wof:placetype":"county",

--- a/data/115/932/149/3/1159321493.geojson
+++ b/data/115/932/149/3/1159321493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.205078,
-    "geom:area_square_m":6989295976.354627,
+    "geom:area_square_m":6989296051.815627,
     "geom:bbox":"27.861322,61.527305,29.696826,62.657022",
     "geom:latitude":62.027148,
     "geom:longitude":28.82847,
@@ -183,7 +183,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415353,
-    "wof:geomhash":"b55206f12f17070b04a22a52d7be1de7",
+    "wof:geomhash":"01e926640b096c57cf1b90ca23415283",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -195,7 +195,7 @@
         }
     ],
     "wof:id":1159321493,
-    "wof:lastmodified":1636494416,
+    "wof:lastmodified":1695886538,
     "wof:name":"Savonlinna",
     "wof:parent_id":85683109,
     "wof:placetype":"county",

--- a/data/115/932/149/5/1159321495.geojson
+++ b/data/115/932/149/5/1159321495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.725766,
-    "geom:area_square_m":4164620418.658724,
+    "geom:area_square_m":4164621997.743872,
     "geom:bbox":"20.466034,61.921668,21.790968,62.767666",
     "geom:latitude":62.352536,
     "geom:longitude":21.157686,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415354,
-    "wof:geomhash":"b888ab72321fed5d78afa54b75766e24",
+    "wof:geomhash":"ffc2a8879ee74e80a56d63f2d45c5ef0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321495,
-    "wof:lastmodified":1627522133,
+    "wof:lastmodified":1695886614,
     "wof:name":"Sydosterbotten",
     "wof:parent_id":85683119,
     "wof:placetype":"county",

--- a/data/115/932/149/7/1159321497.geojson
+++ b/data/115/932/149/7/1159321497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.018867,
-    "geom:area_square_m":10407904065.666029,
+    "geom:area_square_m":10407904065.666557,
     "geom:bbox":"24.1374891017,64.5581853075,28.1643122064,65.960359611",
     "geom:latitude":65.358843,
     "geom:longitude":26.578603,
@@ -78,7 +78,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415355,
-    "wof:geomhash":"318ab33130a858b8a1022a85e92ae548",
+    "wof:geomhash":"93478401995e8ac1fa0f40db38cc74d2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1159321497,
-    "wof:lastmodified":1566595587,
+    "wof:lastmodified":1695886735,
     "wof:name":"Oulunkaari",
     "wof:parent_id":85683143,
     "wof:placetype":"county",

--- a/data/115/932/149/9/1159321499.geojson
+++ b/data/115/932/149/9/1159321499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.380524,
-    "geom:area_square_m":2183053729.192623,
+    "geom:area_square_m":2183053729.19265,
     "geom:bbox":"24.013003209,62.0231917496,25.2519130863,62.665662886",
     "geom:latitude":62.356906,
     "geom:longitude":24.650553,
@@ -150,7 +150,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415358,
-    "wof:geomhash":"2aadf0844e184bc7c1dfe85a99245ebe",
+    "wof:geomhash":"8d9ed38afa472a6a9d67f9ec9de60409",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -162,7 +162,7 @@
         }
     ],
     "wof:id":1159321499,
-    "wof:lastmodified":1566595585,
+    "wof:lastmodified":1695886734,
     "wof:name":"Keuruu",
     "wof:parent_id":85683117,
     "wof:placetype":"county",

--- a/data/115/932/150/1/1159321501.geojson
+++ b/data/115/932/150/1/1159321501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.536064,
-    "geom:area_square_m":8579804404.872643,
+    "geom:area_square_m":8579804404.872532,
     "geom:bbox":"20.1658189049,62.6561838868,22.6582020865,63.6702322589",
     "geom:latitude":63.145569,
     "geom:longitude":21.27964,
@@ -219,7 +219,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415359,
-    "wof:geomhash":"f4437c8a20b4ebec896d15ff999cdb87",
+    "wof:geomhash":"ac3fc36c845c11cac82ecaaca5ac41bf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -231,7 +231,7 @@
         }
     ],
     "wof:id":1159321501,
-    "wof:lastmodified":1566595474,
+    "wof:lastmodified":1695886711,
     "wof:name":"Vaasa",
     "wof:parent_id":85683119,
     "wof:placetype":"county",

--- a/data/115/932/150/3/1159321503.geojson
+++ b/data/115/932/150/3/1159321503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.202674,
-    "geom:area_square_m":7417710187.595938,
+    "geom:area_square_m":7417710187.595958,
     "geom:bbox":"19.9406472182,59.4541440185,21.345645063,60.8766366924",
     "geom:latitude":60.07946,
     "geom:longitude":20.662252,
@@ -390,7 +390,7 @@
     ],
     "wof:country":"FI",
     "wof:created":1526415359,
-    "wof:geomhash":"deee83a1eae2f18ae0d961bade73d36c",
+    "wof:geomhash":"f16f2be30fc291f0a8b47f61a4ef81c8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +400,7 @@
         }
     ],
     "wof:id":1159321503,
-    "wof:lastmodified":1566595475,
+    "wof:lastmodified":1695886711,
     "wof:name":"Archipelago",
     "wof:parent_id":85632789,
     "wof:placetype":"county",

--- a/data/115/932/150/5/1159321505.geojson
+++ b/data/115/932/150/5/1159321505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.367144,
-    "geom:area_square_m":2214690222.050118,
+    "geom:area_square_m":2214690222.050137,
     "geom:bbox":"22.1603136299,60.5108829419,23.2995858448,61.1014353236",
     "geom:latitude":60.801346,
     "geom:longitude":22.797269,
@@ -144,7 +144,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415360,
-    "wof:geomhash":"87b3b8b5fb4c6f5909f7d77be246d177",
+    "wof:geomhash":"5751a9f820c586dc4922803fd2b56258",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -156,7 +156,7 @@
         }
     ],
     "wof:id":1159321505,
-    "wof:lastmodified":1566595475,
+    "wof:lastmodified":1695886711,
     "wof:name":"Loimaa",
     "wof:parent_id":85683073,
     "wof:placetype":"county",

--- a/data/115/932/150/7/1159321507.geojson
+++ b/data/115/932/150/7/1159321507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.432874,
-    "geom:area_square_m":2558818963.853144,
+    "geom:area_square_m":2558818963.853097,
     "geom:bbox":"28.2521979392,61.0792549913,30.143955961,61.8643164367",
     "geom:latitude":61.441492,
     "geom:longitude":29.094629,
@@ -183,7 +183,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415366,
-    "wof:geomhash":"c3b8d8ca5e912c0b75245e4592ac38fd",
+    "wof:geomhash":"55347d886aa333d51e1655ee109889fd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -195,7 +195,7 @@
         }
     ],
     "wof:id":1159321507,
-    "wof:lastmodified":1566595473,
+    "wof:lastmodified":1695886710,
     "wof:name":"Imatra",
     "wof:parent_id":85683103,
     "wof:placetype":"county",

--- a/data/115/932/151/1/1159321511.geojson
+++ b/data/115/932/151/1/1159321511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.244581,
-    "geom:area_square_m":1473919424.536149,
+    "geom:area_square_m":1473919424.536209,
     "geom:bbox":"23.1356381342,60.6376627449,24.0632433773,61.0208919483",
     "geom:latitude":60.832718,
     "geom:longitude":23.635213,
@@ -153,7 +153,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415366,
-    "wof:geomhash":"d46192fa5eb525f84efe4d61e39cd084",
+    "wof:geomhash":"f6d6bf4f5ec0c695812f6b0aa608cfd3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +165,7 @@
         }
     ],
     "wof:id":1159321511,
-    "wof:lastmodified":1566595510,
+    "wof:lastmodified":1695886720,
     "wof:name":"Forssa",
     "wof:parent_id":85683077,
     "wof:placetype":"county",

--- a/data/115/932/151/3/1159321513.geojson
+++ b/data/115/932/151/3/1159321513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.505597,
-    "geom:area_square_m":3027555138.007479,
+    "geom:area_square_m":3027555190.540935,
     "geom:bbox":"23.756757,60.744569,25.269663,61.324881",
     "geom:latitude":61.035352,
     "geom:longitude":24.556838,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415373,
-    "wof:geomhash":"0e7267a0d4db077f94b9202f910e029a",
+    "wof:geomhash":"20590820f05c33b542f0b0a0cf1a8175",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321513,
-    "wof:lastmodified":1627522119,
+    "wof:lastmodified":1695886589,
     "wof:name":"Hameenlinna",
     "wof:parent_id":85683077,
     "wof:placetype":"county",

--- a/data/115/932/151/5/1159321515.geojson
+++ b/data/115/932/151/5/1159321515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.301681,
-    "geom:area_square_m":7292808791.016761,
+    "geom:area_square_m":7292808443.702616,
     "geom:bbox":"24.215557,62.520833,26.334274,63.612293",
     "geom:latitude":63.057302,
     "geom:longitude":25.277819,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415379,
-    "wof:geomhash":"62403b131950834919698641b37d1730",
+    "wof:geomhash":"08fe7f952c5329429e1f8e105f3f22fd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321515,
-    "wof:lastmodified":1627522130,
+    "wof:lastmodified":1695886607,
     "wof:name":"Saarijarvi-Viitasaari",
     "wof:parent_id":85683117,
     "wof:placetype":"county",

--- a/data/115/932/151/7/1159321517.geojson
+++ b/data/115/932/151/7/1159321517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.571178,
-    "geom:area_square_m":3299749351.735466,
+    "geom:area_square_m":3299749069.384045,
     "geom:bbox":"29.295965,61.722073,30.789182,62.416344",
     "geom:latitude":62.146795,
     "geom:longitude":29.992562,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415385,
-    "wof:geomhash":"aa4375461b04f99ba44806ed93ea299a",
+    "wof:geomhash":"32eaa768b891981ae5e3a37dd6db5010",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321517,
-    "wof:lastmodified":1627522114,
+    "wof:lastmodified":1695886587,
     "wof:name":"Keski-Karjala",
     "wof:parent_id":85683133,
     "wof:placetype":"county",

--- a/data/115/932/151/9/1159321519.geojson
+++ b/data/115/932/151/9/1159321519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.388593,
-    "geom:area_square_m":2260031363.639192,
+    "geom:area_square_m":2260031402.737152,
     "geom:bbox":"21.678974,61.686067,22.861626,62.311104",
     "geom:latitude":61.943069,
     "geom:longitude":22.339179,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415387,
-    "wof:geomhash":"d57bbac22a67a0ba6615e3fc431b217e",
+    "wof:geomhash":"d6db876b87bac3b24d2e4a2d1e5125c6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321519,
-    "wof:lastmodified":1642551770,
+    "wof:lastmodified":1695886515,
     "wof:name":"Pohjois-Satakunta",
     "wof:parent_id":85683095,
     "wof:placetype":"county",

--- a/data/115/932/152/1/1159321521.geojson
+++ b/data/115/932/152/1/1159321521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.821962,
-    "geom:area_square_m":4848218615.934048,
+    "geom:area_square_m":4848218615.93405,
     "geom:bbox":"22.8240685249,61.1995966763,24.9704799176,61.8629895063",
     "geom:latitude":61.509442,
     "geom:longitude":24.021848,
@@ -327,7 +327,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415388,
-    "wof:geomhash":"9aeb385d51707b20d71a2c446f1b73ca",
+    "wof:geomhash":"5f954924b2f5383601d9e7414edf3190",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -339,7 +339,7 @@
         }
     ],
     "wof:id":1159321521,
-    "wof:lastmodified":1566595573,
+    "wof:lastmodified":1695886730,
     "wof:name":"Tampere",
     "wof:parent_id":85683099,
     "wof:placetype":"county",

--- a/data/115/932/152/3/1159321523.geojson
+++ b/data/115/932/152/3/1159321523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.353148,
-    "geom:area_square_m":11632747704.288523,
+    "geom:area_square_m":11632747402.969984,
     "geom:bbox":"24.736849,65.70064,27.494588,67.179768",
     "geom:latitude":66.434354,
     "geom:longitude":26.080882,
@@ -258,7 +258,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415389,
-    "wof:geomhash":"8f19cc851117c0ba17697dc88d96aaf3",
+    "wof:geomhash":"ea1f0df553dc99ae3c31dec2f066f5ad",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -270,7 +270,7 @@
         }
     ],
     "wof:id":1159321523,
-    "wof:lastmodified":1642551804,
+    "wof:lastmodified":1695886526,
     "wof:name":"Rovaniemi",
     "wof:parent_id":85683147,
     "wof:placetype":"county",

--- a/data/115/932/152/5/1159321525.geojson
+++ b/data/115/932/152/5/1159321525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340545,
-    "geom:area_square_m":2079277486.396231,
+    "geom:area_square_m":2079277486.395858,
     "geom:bbox":"25.8010023716,60.0446972153,26.6563967257,60.7623454028",
     "geom:latitude":60.4108,
     "geom:longitude":26.233959,
@@ -153,7 +153,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415390,
-    "wof:geomhash":"9196d568b618fd43a060982d8605e60a",
+    "wof:geomhash":"c793772e4fe851686f044734bd22d773",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +165,7 @@
         }
     ],
     "wof:id":1159321525,
-    "wof:lastmodified":1566595576,
+    "wof:lastmodified":1695886731,
     "wof:name":"Loviisa",
     "wof:parent_id":85683067,
     "wof:placetype":"county",

--- a/data/115/932/152/9/1159321529.geojson
+++ b/data/115/932/152/9/1159321529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.377515,
-    "geom:area_square_m":7196755551.625762,
+    "geom:area_square_m":7196757260.391117,
     "geom:bbox":"24.038591,64.462682,26.771562,65.572621",
     "geom:latitude":65.006343,
     "geom:longitude":25.586023,
@@ -297,7 +297,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415390,
-    "wof:geomhash":"ed6681ce15a41d4359df82478072c385",
+    "wof:geomhash":"a931c09fdb8be7b09d149e43e80a4e32",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +309,7 @@
         }
     ],
     "wof:id":1159321529,
-    "wof:lastmodified":1636494415,
+    "wof:lastmodified":1695886536,
     "wof:name":"Oulu",
     "wof:parent_id":85683143,
     "wof:placetype":"county",

--- a/data/115/932/153/1/1159321531.geojson
+++ b/data/115/932/153/1/1159321531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.751347,
-    "geom:area_square_m":34871830315.169991,
+    "geom:area_square_m":34871832540.426025,
     "geom:bbox":"24.903166,66.942924,29.336496,70.092293",
     "geom:latitude":68.662531,
     "geom:longitude":27.081105,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415391,
-    "wof:geomhash":"78b05d55df3087991f30845c68fa2acc",
+    "wof:geomhash":"6a1cd202fce7cb56d4cf6e33e367de4e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321531,
-    "wof:lastmodified":1627522128,
+    "wof:lastmodified":1695886604,
     "wof:name":"Pohjois-Lappi",
     "wof:parent_id":85683147,
     "wof:placetype":"county",

--- a/data/115/932/153/3/1159321533.geojson
+++ b/data/115/932/153/3/1159321533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.592547,
-    "geom:area_square_m":3447276536.553558,
+    "geom:area_square_m":3447276562.241789,
     "geom:bbox":"22.52075,61.516087,23.885111,62.334167",
     "geom:latitude":61.933591,
     "geom:longitude":23.25121,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415392,
-    "wof:geomhash":"899797b9e167743116470742ac07063d",
+    "wof:geomhash":"4bb53b672369f7597d9b83456f6b0601",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321533,
-    "wof:lastmodified":1627522127,
+    "wof:lastmodified":1695886603,
     "wof:name":"Luoteis-Pirkanmaa",
     "wof:parent_id":85683099,
     "wof:placetype":"county",

--- a/data/115/932/153/5/1159321535.geojson
+++ b/data/115/932/153/5/1159321535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.469426,
-    "geom:area_square_m":21578090880.986591,
+    "geom:area_square_m":21578089645.475891,
     "geom:bbox":"26.468145,65.800595,30.017044,68.196304",
     "geom:latitude":67.016542,
     "geom:longitude":28.254846,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415393,
-    "wof:geomhash":"62aeda6e4767f16114ecca96d3c89916",
+    "wof:geomhash":"0fcb1ce03e79e828fc72298793f62707",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321535,
-    "wof:lastmodified":1627522120,
+    "wof:lastmodified":1695886591,
     "wof:name":"Ita-Lappi",
     "wof:parent_id":85683147,
     "wof:placetype":"county",

--- a/data/115/932/153/7/1159321537.geojson
+++ b/data/115/932/153/7/1159321537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.82448,
-    "geom:area_square_m":4048681162.352028,
+    "geom:area_square_m":4048680734.495867,
     "geom:bbox":"23.642878,66.165275,25.050411,67.014925",
     "geom:latitude":66.600981,
     "geom:longitude":24.348136,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415396,
-    "wof:geomhash":"4a5cf870a1318e9996716a4d3f04005c",
+    "wof:geomhash":"367abff9243d5ea3eb5fad52717a9488",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321537,
-    "wof:lastmodified":1627522133,
+    "wof:lastmodified":1695886615,
     "wof:name":"Torniolaakso",
     "wof:parent_id":85683147,
     "wof:placetype":"county",

--- a/data/115/932/153/9/1159321539.geojson
+++ b/data/115/932/153/9/1159321539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.389558,
-    "geom:area_square_m":8157929723.046776,
+    "geom:area_square_m":8157930008.668298,
     "geom:bbox":"26.220723,61.151302,28.817866,62.307726",
     "geom:latitude":61.653947,
     "geom:longitude":27.164006,
@@ -222,7 +222,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415397,
-    "wof:geomhash":"4b33077cfa30cb63a35ea4d862999a57",
+    "wof:geomhash":"8d4536c05538b67d7128cdad5b2fdd12",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -234,7 +234,7 @@
         }
     ],
     "wof:id":1159321539,
-    "wof:lastmodified":1636494413,
+    "wof:lastmodified":1695886532,
     "wof:name":"Mikkeli",
     "wof:parent_id":85683109,
     "wof:placetype":"county",

--- a/data/115/932/154/1/1159321541.geojson
+++ b/data/115/932/154/1/1159321541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.194091,
-    "geom:area_square_m":1173624442.788891,
+    "geom:area_square_m":1173624386.123827,
     "geom:bbox":"24.046748,60.552491,25.193067,60.927839",
     "geom:latitude":60.724127,
     "geom:longitude":24.592054,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415399,
-    "wof:geomhash":"335104d1158367c6353526a03379494f",
+    "wof:geomhash":"f976f9d9901321c1236acbfdb9944b23",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321541,
-    "wof:lastmodified":1627522129,
+    "wof:lastmodified":1695886606,
     "wof:name":"Riihimaki",
     "wof:parent_id":85683077,
     "wof:placetype":"county",

--- a/data/115/932/154/3/1159321543.geojson
+++ b/data/115/932/154/3/1159321543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.468225,
-    "geom:area_square_m":2689428112.820652,
+    "geom:area_square_m":2689428112.820616,
     "geom:bbox":"21.5115772001,61.9797595844,22.6632539811,62.6432466531",
     "geom:latitude":62.320717,
     "geom:longitude":22.042872,
@@ -78,7 +78,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415401,
-    "wof:geomhash":"6b04e914137ae050879bf10de52c8638",
+    "wof:geomhash":"1ff7d547ef07362766c809e47bef983b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1159321543,
-    "wof:lastmodified":1566595542,
+    "wof:lastmodified":1695886723,
     "wof:name":"Suupohja",
     "wof:parent_id":85683113,
     "wof:placetype":"county",

--- a/data/115/932/154/7/1159321547.geojson
+++ b/data/115/932/154/7/1159321547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.714176,
-    "geom:area_square_m":4273763535.257622,
+    "geom:area_square_m":4273763535.257573,
     "geom:bbox":"27.1210694294,60.6666580609,28.776648522,61.379686546",
     "geom:latitude":61.055911,
     "geom:longitude":27.944268,
@@ -237,7 +237,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415401,
-    "wof:geomhash":"391efb68a6204fb8e0a1a1a03baf296f",
+    "wof:geomhash":"7839a79a104e2fce423217409ae67316",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -249,7 +249,7 @@
         }
     ],
     "wof:id":1159321547,
-    "wof:lastmodified":1566595540,
+    "wof:lastmodified":1695886723,
     "wof:name":"Lappeenranta",
     "wof:parent_id":85683103,
     "wof:placetype":"county",

--- a/data/115/932/154/9/1159321549.geojson
+++ b/data/115/932/154/9/1159321549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.899394,
-    "geom:area_square_m":15335539837.720484,
+    "geom:area_square_m":15335540666.70656,
     "geom:bbox":"27.118442,63.703356,30.553557,65.520852",
     "geom:latitude":64.67436,
     "geom:longitude":29.037611,
@@ -81,7 +81,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415402,
-    "wof:geomhash":"21fb95d0ad3a7940f4f8909504b6efb3",
+    "wof:geomhash":"33ede0cded7a6a3ca61bd7e6dfb81688",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -93,7 +93,7 @@
         }
     ],
     "wof:id":1159321549,
-    "wof:lastmodified":1627522122,
+    "wof:lastmodified":1695886596,
     "wof:name":"Kehys-Kainuu",
     "wof:parent_id":85683137,
     "wof:placetype":"county",

--- a/data/115/932/155/1/1159321551.geojson
+++ b/data/115/932/155/1/1159321551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.023599,
-    "geom:area_square_m":11434022677.046539,
+    "geom:area_square_m":11434022677.045958,
     "geom:bbox":"28.6108041267,62.2508029454,31.5867039408,63.4497155616",
     "geom:latitude":62.808886,
     "geom:longitude":30.039655,
@@ -243,7 +243,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415403,
-    "wof:geomhash":"0e936a920ff7b2c0bfc997443ea5e037",
+    "wof:geomhash":"150f2d934f534443d841bae13d6a99f3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -255,7 +255,7 @@
         }
     ],
     "wof:id":1159321551,
-    "wof:lastmodified":1566595566,
+    "wof:lastmodified":1695886728,
     "wof:name":"Joensuu",
     "wof:parent_id":85683133,
     "wof:placetype":"county",

--- a/data/115/932/155/3/1159321553.geojson
+++ b/data/115/932/155/3/1159321553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318703,
-    "geom:area_square_m":1808244059.237748,
+    "geom:area_square_m":1808243829.309913,
     "geom:bbox":"25.473974,62.478514,26.599088,62.920775",
     "geom:latitude":62.687014,
     "geom:longitude":26.007683,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415404,
-    "wof:geomhash":"2d57d70a73a0e06fcef3edf6d31db9a7",
+    "wof:geomhash":"5e3e9ea547cbde4c901089359c9cc620",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321553,
-    "wof:lastmodified":1627522114,
+    "wof:lastmodified":1695886587,
     "wof:name":"Aanekoski",
     "wof:parent_id":85683117,
     "wof:placetype":"county",

--- a/data/115/932/155/5/1159321555.geojson
+++ b/data/115/932/155/5/1159321555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.445209,
-    "geom:area_square_m":2531866826.812195,
+    "geom:area_square_m":2531866893.021535,
     "geom:bbox":"23.161226,62.363326,24.584282,62.919732",
     "geom:latitude":62.618454,
     "geom:longitude":23.796505,
@@ -84,7 +84,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415404,
-    "wof:geomhash":"b386a3b8228fb3ad0368961471249305",
+    "wof:geomhash":"ff28c1feb86ffab7f95426a0d5b7df6d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -96,7 +96,7 @@
         }
     ],
     "wof:id":1159321555,
-    "wof:lastmodified":1627522125,
+    "wof:lastmodified":1695886599,
     "wof:name":"Kuusiokunnat",
     "wof:parent_id":85683113,
     "wof:placetype":"county",

--- a/data/115/932/155/7/1159321557.geojson
+++ b/data/115/932/155/7/1159321557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.591057,
-    "geom:area_square_m":3550031884.457733,
+    "geom:area_square_m":3550031884.458149,
     "geom:bbox":"25.9919257035,60.5750064462,27.4283596989,61.292578649",
     "geom:latitude":60.939058,
     "geom:longitude":26.678205,
@@ -195,7 +195,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415405,
-    "wof:geomhash":"f74d9cedf1db8dcd93c66dae9ed2ecd6",
+    "wof:geomhash":"3a2e70a31356e5065e12f10003d3b08d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -207,7 +207,7 @@
         }
     ],
     "wof:id":1159321557,
-    "wof:lastmodified":1566595563,
+    "wof:lastmodified":1695886726,
     "wof:name":"Kouvola",
     "wof:parent_id":85683081,
     "wof:placetype":"county",

--- a/data/115/932/155/9/1159321559.geojson
+++ b/data/115/932/155/9/1159321559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.263338,
-    "geom:area_square_m":6380134853.520582,
+    "geom:area_square_m":6380135698.782127,
     "geom:bbox":"23.753599,65.29248,26.067324,66.337641",
     "geom:latitude":65.89484,
     "geom:longitude":24.829992,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415406,
-    "wof:geomhash":"95fc47033dee8f23e7131901b8335acd",
+    "wof:geomhash":"8a2b476ed8dcb482ab279ff443c30a6b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321559,
-    "wof:lastmodified":1642551756,
+    "wof:lastmodified":1695886510,
     "wof:name":"Kemi-Tornio",
     "wof:parent_id":85683147,
     "wof:placetype":"county",

--- a/data/115/932/156/1/1159321561.geojson
+++ b/data/115/932/156/1/1159321561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.033233,
-    "geom:area_square_m":5837052955.440741,
+    "geom:area_square_m":5837052781.754878,
     "geom:bbox":"21.656976,62.269006,23.54054,63.398961",
     "geom:latitude":62.814232,
     "geom:longitude":22.800544,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415407,
-    "wof:geomhash":"e05d998228500775259fd9c67676d1f4",
+    "wof:geomhash":"c53cdc08c04eff14af9ad503f58a7b0d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321561,
-    "wof:lastmodified":1627522131,
+    "wof:lastmodified":1695886611,
     "wof:name":"Seinajoki",
     "wof:parent_id":85683113,
     "wof:placetype":"county",

--- a/data/115/932/156/5/1159321565.geojson
+++ b/data/115/932/156/5/1159321565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.172049,
-    "geom:area_square_m":6910966721.643808,
+    "geom:area_square_m":6910966721.644015,
     "geom:bbox":"20.8120814968,60.9825861877,23.0062343098,62.0245911947",
     "geom:latitude":61.519326,
     "geom:longitude":21.744809,
@@ -219,7 +219,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415409,
-    "wof:geomhash":"3d151096db9408044b5b302a639a6137",
+    "wof:geomhash":"cd235b0f4f4668734a04b90af89ead71",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -231,7 +231,7 @@
         }
     ],
     "wof:id":1159321565,
-    "wof:lastmodified":1566595524,
+    "wof:lastmodified":1695886722,
     "wof:name":"Pori",
     "wof:parent_id":85683095,
     "wof:placetype":"county",

--- a/data/115/932/156/7/1159321567.geojson
+++ b/data/115/932/156/7/1159321567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.509889,
-    "geom:area_square_m":2855893696.164463,
+    "geom:area_square_m":2855893519.949883,
     "geom:bbox":"23.196138,62.675552,24.519592,63.498047",
     "geom:latitude":63.065683,
     "geom:longitude":23.856493,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415410,
-    "wof:geomhash":"b5dc84cd2c4a5f5a1860653861ea83f8",
+    "wof:geomhash":"4fc3a9449a6591cb90e49442b894ed06",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321567,
-    "wof:lastmodified":1627522121,
+    "wof:lastmodified":1695886593,
     "wof:name":"Jarviseutu",
     "wof:parent_id":85683113,
     "wof:placetype":"county",

--- a/data/115/932/156/9/1159321569.geojson
+++ b/data/115/932/156/9/1159321569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.893197,
-    "geom:area_square_m":4814689359.022779,
+    "geom:area_square_m":4814689359.02297,
     "geom:bbox":"22.7788967491,63.6486583527,25.2629849953,64.4834607182",
     "geom:latitude":64.154282,
     "geom:longitude":24.132098,
@@ -147,7 +147,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415410,
-    "wof:geomhash":"5377b2f08246ddf5c0db8fefc6565796",
+    "wof:geomhash":"63d9d8064dce1bd159997670e2628e24",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -159,7 +159,7 @@
         }
     ],
     "wof:id":1159321569,
-    "wof:lastmodified":1566595517,
+    "wof:lastmodified":1695886721,
     "wof:name":"Ylivieska",
     "wof:parent_id":85683143,
     "wof:placetype":"county",

--- a/data/115/932/157/1/1159321571.geojson
+++ b/data/115/932/157/1/1159321571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.769331,
-    "geom:area_square_m":4136459872.431463,
+    "geom:area_square_m":4136459915.571858,
     "geom:bbox":"24.86517,63.841035,26.870402,64.628943",
     "geom:latitude":64.225724,
     "geom:longitude":25.916189,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415413,
-    "wof:geomhash":"baeb5c147e47d60ce358ce86ad7fd240",
+    "wof:geomhash":"b31e6fa955b95efc19df2dda0c37ebab",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321571,
-    "wof:lastmodified":1627522118,
+    "wof:lastmodified":1695886588,
     "wof:name":"Haapavesi-Siikalatva",
     "wof:parent_id":85683143,
     "wof:placetype":"county",

--- a/data/115/932/157/3/1159321573.geojson
+++ b/data/115/932/157/3/1159321573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.634369,
-    "geom:area_square_m":3863532373.600622,
+    "geom:area_square_m":3863533219.950755,
     "geom:bbox":"26.44784,60.171329,27.991283,60.84264",
     "geom:latitude":60.492268,
     "geom:longitude":27.194373,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415415,
-    "wof:geomhash":"5879d2963ee40de2ddacab3f90af3abb",
+    "wof:geomhash":"8ab1c89efc6e6daa2a0a9880d87d85a2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321573,
-    "wof:lastmodified":1627522124,
+    "wof:lastmodified":1695886598,
     "wof:name":"Kotka-Hamina",
     "wof:parent_id":85683081,
     "wof:placetype":"county",

--- a/data/115/932/157/5/1159321575.geojson
+++ b/data/115/932/157/5/1159321575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.216078,
-    "geom:area_square_m":6718606983.791854,
+    "geom:area_square_m":6718608006.45569,
     "geom:bbox":"28.359723,62.998403,31.240846,63.882415",
     "geom:latitude":63.460964,
     "geom:longitude":29.74788,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415416,
-    "wof:geomhash":"498f8cfad4a2b83dd49267b72148c340",
+    "wof:geomhash":"786431f4309b8a7fcc08d0d9801f8c55",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321575,
-    "wof:lastmodified":1627522127,
+    "wof:lastmodified":1695886603,
     "wof:name":"Pielisen Karjala",
     "wof:parent_id":85683133,
     "wof:placetype":"county",

--- a/data/115/932/157/7/1159321577.geojson
+++ b/data/115/932/157/7/1159321577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003346,
-    "geom:area_square_m":20632911.367524,
+    "geom:area_square_m":20632935.788303,
     "geom:bbox":"19.913108,60.046665,19.973286,60.128986",
     "geom:latitude":60.087881,
     "geom:longitude":19.94251,
@@ -64,7 +64,7 @@
     ],
     "wof:country":"FI",
     "wof:created":1526415416,
-    "wof:geomhash":"977ad97da2b763e63acae4cb7223878e",
+    "wof:geomhash":"5c6b1119ea9c61b33e790929f9137f1b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1159321577,
-    "wof:lastmodified":1642551812,
+    "wof:lastmodified":1695886531,
     "wof:name":"Maarianhamina",
     "wof:parent_id":85667871,
     "wof:placetype":"county",

--- a/data/115/932/157/9/1159321579.geojson
+++ b/data/115/932/157/9/1159321579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.484992,
-    "geom:area_square_m":2707570009.930918,
+    "geom:area_square_m":2707569537.018641,
     "geom:bbox":"28.037686,62.580092,29.097602,63.755002",
     "geom:latitude":63.160435,
     "geom:longitude":28.520535,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415417,
-    "wof:geomhash":"9ebd95c870bfd971f78152b687e2e521",
+    "wof:geomhash":"8cf135da53a6ee75347903599419f090",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321579,
-    "wof:lastmodified":1627522123,
+    "wof:lastmodified":1695886596,
     "wof:name":"Koillis-Savo",
     "wof:parent_id":85683131,
     "wof:placetype":"county",

--- a/data/115/932/158/3/1159321583.geojson
+++ b/data/115/932/158/3/1159321583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.586557,
-    "geom:area_square_m":21162765270.976437,
+    "geom:area_square_m":21162765378.597183,
     "geom:bbox":"20.548636,66.937907,26.00784,69.311884",
     "geom:latitude":68.088778,
     "geom:longitude":23.946601,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415419,
-    "wof:geomhash":"5d305393d15b835e1c834facbf3046b1",
+    "wof:geomhash":"d7ad0f1c1b1b1643585cfb8b2a0fc0d5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321583,
-    "wof:lastmodified":1627522134,
+    "wof:lastmodified":1695886616,
     "wof:name":"Tunturi-Lappi",
     "wof:parent_id":85683147,
     "wof:placetype":"county",

--- a/data/115/932/158/5/1159321585.geojson
+++ b/data/115/932/158/5/1159321585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.466705,
-    "geom:area_square_m":2849937354.509153,
+    "geom:area_square_m":2849937354.509274,
     "geom:bbox":"22.7909832536,59.9952092374,23.9205491095,60.7741682465",
     "geom:latitude":60.406152,
     "geom:longitude":23.31727,
@@ -123,7 +123,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415420,
-    "wof:geomhash":"058f83a4c7125e83c03f0f5adaa10d47",
+    "wof:geomhash":"ea87d0e77620a3cf738181c7ec2bd928",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -135,7 +135,7 @@
         }
     ],
     "wof:id":1159321585,
-    "wof:lastmodified":1566595507,
+    "wof:lastmodified":1695886719,
     "wof:name":"Salo",
     "wof:parent_id":85683073,
     "wof:placetype":"county",

--- a/data/115/932/158/7/1159321587.geojson
+++ b/data/115/932/158/7/1159321587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.469918,
-    "geom:area_square_m":2744378432.10988,
+    "geom:area_square_m":2744377717.951768,
     "geom:bbox":"24.524644,61.450703,25.596223,62.210801",
     "geom:latitude":61.81591,
     "geom:longitude":25.09953,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415421,
-    "wof:geomhash":"9a61816da15919aebe85f3df1fd650c0",
+    "wof:geomhash":"be322779b04c5ec4c4429d894997ebf2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321587,
-    "wof:lastmodified":1627522120,
+    "wof:lastmodified":1695886593,
     "wof:name":"Jamsa",
     "wof:parent_id":85683117,
     "wof:placetype":"county",

--- a/data/115/932/158/9/1159321589.geojson
+++ b/data/115/932/158/9/1159321589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152801,
-    "geom:area_square_m":860100817.722898,
+    "geom:area_square_m":860100869.742834,
     "geom:bbox":"21.772061,62.751574,22.694183,63.102983",
     "geom:latitude":62.92076,
     "geom:longitude":22.157308,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415421,
-    "wof:geomhash":"48ad9dd7173b678cf9b0c8344b36a0f4",
+    "wof:geomhash":"9f76828eb8dfd55e5f2f72cfbc00915f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321589,
-    "wof:lastmodified":1642551790,
+    "wof:lastmodified":1695886521,
     "wof:name":"Kyronmaa",
     "wof:parent_id":85683119,
     "wof:placetype":"county",

--- a/data/115/932/159/1/1159321591.geojson
+++ b/data/115/932/159/1/1159321591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.725376,
-    "geom:area_square_m":3964671988.868139,
+    "geom:area_square_m":3964672346.258639,
     "geom:bbox":"24.521033,63.429131,26.291966,64.110644",
     "geom:latitude":63.766966,
     "geom:longitude":25.562894,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415421,
-    "wof:geomhash":"8c4dc7cc673b1c23ca0848a5e9d149d7",
+    "wof:geomhash":"41f566af3696e467d4f6acebcdb800b6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321591,
-    "wof:lastmodified":1627522125,
+    "wof:lastmodified":1695886601,
     "wof:name":"Nivala-Haapajarvi",
     "wof:parent_id":85683143,
     "wof:placetype":"county",

--- a/data/115/932/159/3/1159321593.geojson
+++ b/data/115/932/159/3/1159321593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.439574,
-    "geom:area_square_m":2695018766.880246,
+    "geom:area_square_m":2695018213.931373,
     "geom:bbox":"25.329288,59.928196,26.271298,60.735871",
     "geom:latitude":60.275369,
     "geom:longitude":25.71953,
@@ -222,7 +222,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415423,
-    "wof:geomhash":"8104b231c8cce6f2e0cd2b7433d74cb1",
+    "wof:geomhash":"b1526313778fc2bf65067ed3876d735e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -234,7 +234,7 @@
         }
     ],
     "wof:id":1159321593,
-    "wof:lastmodified":1636494412,
+    "wof:lastmodified":1695886531,
     "wof:name":"Porvoo",
     "wof:parent_id":85683067,
     "wof:placetype":"county",

--- a/data/115/932/159/5/1159321595.geojson
+++ b/data/115/932/159/5/1159321595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.586951,
-    "geom:area_square_m":3241332443.974433,
+    "geom:area_square_m":3241332443.974461,
     "geom:bbox":"23.4224071934,63.1164295097,25.0363155553,63.8862213373",
     "geom:latitude":63.473984,
     "geom:longitude":24.281071,
@@ -105,7 +105,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415423,
-    "wof:geomhash":"da58fd7ef2b986da977ea926e8cf8b83",
+    "wof:geomhash":"89410826dd739b28ba7c7d0731ff8270",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":1159321595,
-    "wof:lastmodified":1566595483,
+    "wof:lastmodified":1695886716,
     "wof:name":"Kaustinen",
     "wof:parent_id":85683125,
     "wof:placetype":"county",

--- a/data/115/932/159/7/1159321597.geojson
+++ b/data/115/932/159/7/1159321597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.855922,
-    "geom:area_square_m":4804657578.512277,
+    "geom:area_square_m":4804657578.511948,
     "geom:bbox":"26.890127759,62.5922636488,28.7623868144,63.403310726",
     "geom:latitude":63.001167,
     "geom:longitude":27.763659,
@@ -243,7 +243,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415424,
-    "wof:geomhash":"8a97705b92e952663d6096a415dfd592",
+    "wof:geomhash":"95f568f111ca7404966868c47b0166f8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -255,7 +255,7 @@
         }
     ],
     "wof:id":1159321597,
-    "wof:lastmodified":1566595477,
+    "wof:lastmodified":1695886712,
     "wof:name":"Kuopio",
     "wof:parent_id":85683131,
     "wof:placetype":"county",

--- a/data/115/932/160/1/1159321601.geojson
+++ b/data/115/932/160/1/1159321601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.456892,
-    "geom:area_square_m":8025117493.666729,
+    "geom:area_square_m":8025118004.966552,
     "geom:bbox":"26.070397,62.991834,28.168084,64.036974",
     "geom:latitude":63.546031,
     "geom:longitude":27.05818,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415426,
-    "wof:geomhash":"ed05f93fc35c5cc3643a0df81f8e40bb",
+    "wof:geomhash":"e7d66c6248d3655a368ab2fe58f0a11a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321601,
-    "wof:lastmodified":1627522130,
+    "wof:lastmodified":1695886608,
     "wof:name":"Yla-Savo",
     "wof:parent_id":85683131,
     "wof:placetype":"county",

--- a/data/115/932/160/3/1159321603.geojson
+++ b/data/115/932/160/3/1159321603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.512314,
-    "geom:area_square_m":3118221960.339677,
+    "geom:area_square_m":3118221960.339888,
     "geom:bbox":"21.5058703402,60.2100594187,22.8804460883,60.9042053838",
     "geom:latitude":60.512502,
     "geom:longitude":22.218838,
@@ -342,7 +342,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415433,
-    "wof:geomhash":"753a53a60c4e225be9958f8497c39ef3",
+    "wof:geomhash":"c8f0f089d64b26f75eaa7a9dc0ee4b64",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -354,7 +354,7 @@
         }
     ],
     "wof:id":1159321603,
-    "wof:lastmodified":1566595501,
+    "wof:lastmodified":1695886719,
     "wof:name":"Turku",
     "wof:parent_id":85683073,
     "wof:placetype":"county",

--- a/data/115/932/160/5/1159321605.geojson
+++ b/data/115/932/160/5/1159321605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.340869,
-    "geom:area_square_m":8303416763.607578,
+    "geom:area_square_m":8303418406.086098,
     "geom:bbox":"21.02383,59.475643,22.92042,60.498662",
     "geom:latitude":59.94613,
     "geom:longitude":21.928442,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415434,
-    "wof:geomhash":"873403a1a4d434787aeefa098b080a11",
+    "wof:geomhash":"06cb2fabc4bc586cf88bb510a2f08c89",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321605,
-    "wof:lastmodified":1627522114,
+    "wof:lastmodified":1695886588,
     "wof:name":"Aboland-Turunmaa",
     "wof:parent_id":85683073,
     "wof:placetype":"county",

--- a/data/115/932/160/7/1159321607.geojson
+++ b/data/115/932/160/7/1159321607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.377446,
-    "geom:area_square_m":2254851885.910069,
+    "geom:area_square_m":2254851885.910133,
     "geom:bbox":"20.7731388539,60.8720057423,22.7015445018,61.3087891267",
     "geom:latitude":61.109852,
     "geom:longitude":21.802225,
@@ -117,7 +117,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415434,
-    "wof:geomhash":"8e8b3ff691091d68a3463592420ef393",
+    "wof:geomhash":"273445fb0c797b84dc39176e2d249d64",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -129,7 +129,7 @@
         }
     ],
     "wof:id":1159321607,
-    "wof:lastmodified":1566595494,
+    "wof:lastmodified":1695886718,
     "wof:name":"Rauma",
     "wof:parent_id":85683095,
     "wof:placetype":"county",

--- a/data/115/932/160/9/1159321609.geojson
+++ b/data/115/932/160/9/1159321609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.584993,
-    "geom:area_square_m":3181313366.813217,
+    "geom:area_square_m":3181313366.812986,
     "geom:bbox":"22.287877,63.49911,24.49271,64.178969",
     "geom:latitude":63.90877,
     "geom:longitude":23.4039,
@@ -210,7 +210,7 @@
     ],
     "wof:country":"FI",
     "wof:created":1526415435,
-    "wof:geomhash":"74b55e102c04b484474ba525c08c4029",
+    "wof:geomhash":"609929b21a6db0e884802e883dbece8e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -222,7 +222,7 @@
         }
     ],
     "wof:id":1159321609,
-    "wof:lastmodified":1636494413,
+    "wof:lastmodified":1695886535,
     "wof:name":"Kokkola",
     "wof:parent_id":85683125,
     "wof:placetype":"county",

--- a/data/115/932/161/1/1159321611.geojson
+++ b/data/115/932/161/1/1159321611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.947851,
-    "geom:area_square_m":5813718850.200148,
+    "geom:area_square_m":5813720365.704795,
     "geom:bbox":"19.0832,59.595064,20.564037,60.762002",
     "geom:latitude":60.262895,
     "geom:longitude":19.77276,
@@ -63,7 +63,7 @@
     ],
     "wof:country":"FI",
     "wof:created":1526415435,
-    "wof:geomhash":"588b39f60ecda1818b680a656d1fb7ae",
+    "wof:geomhash":"8b27e8cf56d0027c02f91f9c259ab5b4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":1159321611,
-    "wof:lastmodified":1627522115,
+    "wof:lastmodified":1695886588,
     "wof:name":"Countryside",
     "wof:parent_id":85632789,
     "wof:placetype":"county",

--- a/data/115/932/161/3/1159321613.geojson
+++ b/data/115/932/161/3/1159321613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318008,
-    "geom:area_square_m":1884817302.709874,
+    "geom:area_square_m":1884817612.020987,
     "geom:bbox":"22.43416,61.001219,23.38336,61.723839",
     "geom:latitude":61.358561,
     "geom:longitude":22.932326,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415436,
-    "wof:geomhash":"f13efa92ac4cee075d9e8108c8b7d5a3",
+    "wof:geomhash":"4686ec425601b5467db63353a652f098",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321613,
-    "wof:lastmodified":1627522128,
+    "wof:lastmodified":1695886605,
     "wof:name":"Lounais-Pirkanmaa",
     "wof:parent_id":85683099,
     "wof:placetype":"county",

--- a/data/115/932/161/5/1159321615.geojson
+++ b/data/115/932/161/5/1159321615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.669306,
-    "geom:area_square_m":3870600533.871938,
+    "geom:area_square_m":3870600643.884658,
     "geom:bbox":"26.66197,61.545596,28.227785,62.530018",
     "geom:latitude":62.115693,
     "geom:longitude":27.517259,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415436,
-    "wof:geomhash":"60d47ae87c5fd822fdb1dcd8a6aa2073",
+    "wof:geomhash":"d43066044408d34ee8773157937f6abc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321615,
-    "wof:lastmodified":1627522126,
+    "wof:lastmodified":1695886601,
     "wof:name":"Pieksamaki",
     "wof:parent_id":85683109,
     "wof:placetype":"county",

--- a/data/115/932/161/9/1159321619.geojson
+++ b/data/115/932/161/9/1159321619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.234872,
-    "geom:area_square_m":1371573532.498629,
+    "geom:area_square_m":1371573532.498521,
     "geom:bbox":"25.4970411192,61.6084494151,26.5337514675,62.0432189989",
     "geom:latitude":61.818477,
     "geom:longitude":26.077204,
@@ -120,7 +120,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415437,
-    "wof:geomhash":"c2241572dc20fb5a685f1e027ca7fa1c",
+    "wof:geomhash":"c5320c955801867e6eaf5c4fd3bbaf27",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -132,7 +132,7 @@
         }
     ],
     "wof:id":1159321619,
-    "wof:lastmodified":1566595485,
+    "wof:lastmodified":1695886717,
     "wof:name":"Joutsa",
     "wof:parent_id":85683117,
     "wof:placetype":"county",

--- a/data/115/932/162/1/1159321621.geojson
+++ b/data/115/932/162/1/1159321621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198561,
-    "geom:area_square_m":1184949839.709967,
+    "geom:area_square_m":1184949905.79158,
     "geom:bbox":"23.227298,60.939755,24.297123,61.343825",
     "geom:latitude":61.143303,
     "geom:longitude":23.737314,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415438,
-    "wof:geomhash":"a8c765ee58a943adcfbb72d8fdce3c80",
+    "wof:geomhash":"c23a38a7127c3bbe1841d3e222375a38",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321621,
-    "wof:lastmodified":1627522128,
+    "wof:lastmodified":1695886606,
     "wof:name":"Etela-Pirkanmaa",
     "wof:parent_id":85683099,
     "wof:placetype":"county",

--- a/data/115/932/162/3/1159321623.geojson
+++ b/data/115/932/162/3/1159321623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.47199,
-    "geom:area_square_m":2672162169.8327,
+    "geom:area_square_m":2672162106.604809,
     "geom:bbox":"26.039838,62.423999,27.539485,63.131676",
     "geom:latitude":62.751035,
     "geom:longitude":26.804496,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415439,
-    "wof:geomhash":"4dc5bf727a4fb4c72a928f23bcfbd338",
+    "wof:geomhash":"d17b993abd85e5ba2a668b48a2d5d102",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321623,
-    "wof:lastmodified":1627522132,
+    "wof:lastmodified":1695886612,
     "wof:name":"Sisa-Savo",
     "wof:parent_id":85683131,
     "wof:placetype":"county",

--- a/data/115/932/162/5/1159321625.geojson
+++ b/data/115/932/162/5/1159321625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.769571,
-    "geom:area_square_m":4428835532.769232,
+    "geom:area_square_m":4428835966.121439,
     "geom:bbox":"24.968808,61.839211,26.780303,62.583586",
     "geom:latitude":62.262845,
     "geom:longitude":25.809688,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415442,
-    "wof:geomhash":"839051895587d4c6dd03375f836da6cc",
+    "wof:geomhash":"a0a2e34e1b2da43d346197fffae79385",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321625,
-    "wof:lastmodified":1627522121,
+    "wof:lastmodified":1695886594,
     "wof:name":"Jyvaskyla",
     "wof:parent_id":85683117,
     "wof:placetype":"county",

--- a/data/115/932/162/7/1159321627.geojson
+++ b/data/115/932/162/7/1159321627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.659277,
-    "geom:area_square_m":4087227421.952611,
+    "geom:area_square_m":4087226220.496996,
     "geom:bbox":"22.658924,59.610999,24.316284,60.206001",
     "geom:latitude":59.909867,
     "geom:longitude":23.503794,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415443,
-    "wof:geomhash":"11a7858df048cc72936f4a0db6c88042",
+    "wof:geomhash":"92913fec02d125adf5fb35ade622a590",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321627,
-    "wof:lastmodified":1627522129,
+    "wof:lastmodified":1695886607,
     "wof:name":"Raaseporin",
     "wof:parent_id":85683067,
     "wof:placetype":"county",

--- a/data/115/932/162/9/1159321629.geojson
+++ b/data/115/932/162/9/1159321629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.355355,
-    "geom:area_square_m":2031864777.008118,
+    "geom:area_square_m":2031864777.008854,
     "geom:bbox":"27.4067629758,62.1410078981,28.6588906328,62.7058392858",
     "geom:latitude":62.456874,
     "geom:longitude":28.007469,
@@ -165,7 +165,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415444,
-    "wof:geomhash":"7d9b2d12c8658ff8d7dcd24b2862351d",
+    "wof:geomhash":"128d17a4c6037feab82244e2d5e08206",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -177,7 +177,7 @@
         }
     ],
     "wof:id":1159321629,
-    "wof:lastmodified":1566595544,
+    "wof:lastmodified":1695886724,
     "wof:name":"Varkaus",
     "wof:parent_id":85683131,
     "wof:placetype":"county",

--- a/data/115/932/163/1/1159321631.geojson
+++ b/data/115/932/163/1/1159321631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.920098,
-    "geom:area_square_m":4877811316.713576,
+    "geom:area_square_m":4877811316.713656,
     "geom:bbox":"23.1400486404,64.2996844967,25.6125804107,65.0079473474",
     "geom:latitude":64.612319,
     "geom:longitude":24.478692,
@@ -147,7 +147,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415445,
-    "wof:geomhash":"f7c533280cd2f0b2c12b7800dd5fb146",
+    "wof:geomhash":"b77c17b522c8646ba2eb1c56ffa62c89",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -159,7 +159,7 @@
         }
     ],
     "wof:id":1159321631,
-    "wof:lastmodified":1566595558,
+    "wof:lastmodified":1695886725,
     "wof:name":"Raahe",
     "wof:parent_id":85683143,
     "wof:placetype":"county",

--- a/data/115/932/163/3/1159321633.geojson
+++ b/data/115/932/163/3/1159321633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.160958,
-    "geom:area_square_m":7110364845.223666,
+    "geom:area_square_m":7110364845.223518,
     "geom:bbox":"23.5863109041,59.7915698748,25.5269179793,60.8408511915",
     "geom:latitude":60.309823,
     "geom:longitude":24.678277,
@@ -585,7 +585,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415445,
-    "wof:geomhash":"c200e730f025b71aed7f125f9d05b8a2",
+    "wof:geomhash":"1d86a6192067fb3685e408a4dc2f5894",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -597,7 +597,7 @@
         }
     ],
     "wof:id":1159321633,
-    "wof:lastmodified":1566595559,
+    "wof:lastmodified":1695886726,
     "wof:name":"Helsinki",
     "wof:parent_id":85683067,
     "wof:placetype":"county",

--- a/data/115/932/163/7/1159321637.geojson
+++ b/data/115/932/163/7/1159321637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.653048,
-    "geom:area_square_m":3936377211.443595,
+    "geom:area_square_m":3936379333.427295,
     "geom:bbox":"20.377543,60.430685,22.128467,61.13348",
     "geom:latitude":60.823933,
     "geom:longitude":21.257555,
@@ -81,7 +81,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415446,
-    "wof:geomhash":"37818ad2c9937fb295bd21d95b8b0ce6",
+    "wof:geomhash":"fa269d7dbaec8e45e26bc2b39a30fbe4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -93,7 +93,7 @@
         }
     ],
     "wof:id":1159321637,
-    "wof:lastmodified":1642551729,
+    "wof:lastmodified":1695886501,
     "wof:name":"Vakka-Suomi",
     "wof:parent_id":85683073,
     "wof:placetype":"county",

--- a/data/115/932/163/9/1159321639.geojson
+++ b/data/115/932/163/9/1159321639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.814736,
-    "geom:area_square_m":4475423107.97157,
+    "geom:area_square_m":4475423995.490839,
     "geom:bbox":"21.599474,63.282048,23.835975,64.009382",
     "geom:latitude":63.625197,
     "geom:longitude":22.655295,
@@ -60,7 +60,7 @@
     "wof:concordance":{},
     "wof:country":"FI",
     "wof:created":1526415446,
-    "wof:geomhash":"2b4dac19853e4170c664d8733b28b3d6",
+    "wof:geomhash":"5f2fb7421c5556ac2874598ebbeae9b4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1159321639,
-    "wof:lastmodified":1627522133,
+    "wof:lastmodified":1695886615,
     "wof:name":"Jakobstadsregionen",
     "wof:parent_id":85683119,
     "wof:placetype":"county",

--- a/data/404/227/405/404227405.geojson
+++ b/data/404/227/405/404227405.geojson
@@ -217,7 +217,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493057,
+    "wof:lastmodified":1695884150,
     "wof:name":"Southwest Finland",
     "wof:parent_id":85633143,
     "wof:placetype":"macroregion",

--- a/data/404/227/407/404227407.geojson
+++ b/data/404/227/407/404227407.geojson
@@ -64,7 +64,10 @@
         136253047
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"FI-IS"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FI",
     "wof:geomhash":"7c484b96f86643ff9eb9773936ab184a",
     "wof:hierarchy":[
@@ -84,7 +87,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493059,
+    "wof:lastmodified":1695884159,
     "wof:name":"Eastern Finland",
     "wof:parent_id":85633143,
     "wof:placetype":"macroregion",

--- a/data/404/227/409/404227409.geojson
+++ b/data/404/227/409/404227409.geojson
@@ -108,7 +108,10 @@
         136253047
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"FI-LL"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85683147
     ],
@@ -131,7 +134,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493060,
+    "wof:lastmodified":1695884161,
     "wof:name":"Lapland",
     "wof:parent_id":85633143,
     "wof:placetype":"macroregion",

--- a/data/404/227/411/404227411.geojson
+++ b/data/404/227/411/404227411.geojson
@@ -216,8 +216,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "iso:code":"FI-ES",
         "wd:id":"Q188752"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FI",
     "wof:geomhash":"cf78922b9351424497734da7ff6e2648",
     "wof:hierarchy":[
@@ -237,7 +239,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694639827,
+    "wof:lastmodified":1695884147,
     "wof:name":"Southern Finland Province",
     "wof:parent_id":85633143,
     "wof:placetype":"macroregion",

--- a/data/404/227/415/404227415.geojson
+++ b/data/404/227/415/404227415.geojson
@@ -63,7 +63,10 @@
         136253047
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"FI-OL"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FI",
     "wof:geomhash":"a7f80c1d10228545c558b019ff62bf24",
     "wof:hierarchy":[
@@ -83,7 +86,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493060,
+    "wof:lastmodified":1695884161,
     "wof:name":"Northern Finland",
     "wof:parent_id":85633143,
     "wof:placetype":"macroregion",

--- a/data/404/227/417/404227417.geojson
+++ b/data/404/227/417/404227417.geojson
@@ -64,7 +64,10 @@
         136253047
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"FI-LS"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FI",
     "wof:geomhash":"9d08cbfa35d39033b3ce496f49901691",
     "wof:hierarchy":[
@@ -84,7 +87,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493057,
+    "wof:lastmodified":1695884158,
     "wof:name":"West Finland",
     "wof:parent_id":85633143,
     "wof:placetype":"macroregion",

--- a/data/856/327/89/85632789.geojson
+++ b/data/856/327/89/85632789.geojson
@@ -835,12 +835,14 @@
         "gaul:id":"1242",
         "gn:id":661882,
         "gp:id":12577865,
+        "iso:code":"AX",
         "m49:code":"248",
         "ne:id":1159320621,
         "qs_pg:id":550574,
         "uncrt:id":"FIN",
         "wd:id":"Q5689"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"
@@ -858,7 +860,7 @@
     "wof:lang":[
         "swe"
     ],
-    "wof:lastmodified":1694493032,
+    "wof:lastmodified":1695881385,
     "wof:name":"Aland",
     "wof:parent_id":136253047,
     "wof:placetype":"dependency",

--- a/data/856/331/43/85633143.geojson
+++ b/data/856/331/43/85633143.geojson
@@ -1443,6 +1443,7 @@
         "hasc:id":"FI",
         "icao:code":"OH",
         "ioc:id":"FIN",
+        "iso:code":"FI",
         "itu:id":"FIN",
         "m49:code":"246",
         "marc:id":"fi",
@@ -1455,6 +1456,7 @@
         "wd:id":"Q33",
         "wmo:id":"FI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FI",
     "wof:country_alpha3":"FIN",
     "wof:geom_alt":[
@@ -1479,7 +1481,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694492252,
+    "wof:lastmodified":1695881365,
     "wof:name":"Finland",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/830/67/85683067.geojson
+++ b/data/856/830/67/85683067.geojson
@@ -412,13 +412,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28312,
         "eurostat:nuts_2021_id":"FI1B1",
+        "figov:code":"101",
         "fips:code":"",
         "gn:id":830709,
         "gp:id":29389247,
         "hasc:id":"FI.",
+        "iso:code":"FI-18",
         "unlc:id":"FI-18",
         "wd:id":"Q5711"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"d8f686f99c64148689b8397b4866d8a4",
     "wof:hierarchy":[
@@ -439,7 +445,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1695885215,
     "wof:name":"Uusimaa",
     "wof:parent_id":404227411,
     "wof:placetype":"region",

--- a/data/856/830/73/85683073.geojson
+++ b/data/856/830/73/85683073.geojson
@@ -371,13 +371,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28329,
         "eurostat:nuts_2021_id":"FI1C1",
+        "figov:code":"202",
         "fips:code":"",
         "gn:id":830708,
         "gp:id":29389250,
         "hasc:id":"FI.",
+        "iso:code":"FI-19",
         "unlc:id":"FI-19",
         "wd:id":"Q5712"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"5f236119e862de4a52b99c1b0953cf7a",
     "wof:hierarchy":[
@@ -398,7 +404,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493265,
+    "wof:lastmodified":1695885216,
     "wof:name":"Southwest Finland",
     "wof:parent_id":404227405,
     "wof:placetype":"region",

--- a/data/856/830/77/85683077.geojson
+++ b/data/856/830/77/85683077.geojson
@@ -377,13 +377,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28314,
         "eurostat:nuts_2021_id":"FI1C2",
+        "figov:code":"105",
         "fips:code":"",
         "gn:id":830705,
         "gp:id":29389249,
         "hasc:id":"FI.",
+        "iso:code":"FI-06",
         "unlc:id":"FI-06",
         "wd:id":"Q5695"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"64a2eaecfcc6bfe925892bc14d836e3a",
     "wof:hierarchy":[
@@ -404,7 +410,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493266,
+    "wof:lastmodified":1695885217,
     "wof:name":"Tavastia Proper",
     "wof:parent_id":404227411,
     "wof:placetype":"region",

--- a/data/856/830/81/85683081.geojson
+++ b/data/856/830/81/85683081.geojson
@@ -359,13 +359,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28316,
         "eurostat:nuts_2021_id":"FI1C4",
+        "figov:code":"108",
         "fips:code":"",
         "gn:id":830703,
         "gp:id":-29389251,
         "hasc:id":"FI.",
+        "iso:code":"FI-09",
         "unlc:id":"FI-09",
         "wd:id":"Q5698"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"e6f6e905c45feda0b2e60e321e799f35",
     "wof:hierarchy":[
@@ -386,7 +392,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493266,
+    "wof:lastmodified":1695885217,
     "wof:name":"Kymenlaakso",
     "wof:parent_id":404227411,
     "wof:placetype":"region",

--- a/data/856/830/91/85683091.geojson
+++ b/data/856/830/91/85683091.geojson
@@ -288,9 +288,15 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28317,
         "eurostat:nuts_2021_id":"FI1C3",
+        "figov:code":"107",
         "gp:id":29389255,
+        "iso:code":"FI-16",
         "wd:id":"Q5708"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"27b4a66643297af8dbb7e9b58bcbd7b8",
     "wof:hierarchy":[
@@ -311,7 +317,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493267,
+    "wof:lastmodified":1695885218,
     "wof:name":"Paijanne Tavastia",
     "wof:parent_id":404227411,
     "wof:placetype":"region",

--- a/data/856/830/95/85683095.geojson
+++ b/data/856/830/95/85683095.geojson
@@ -369,13 +369,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28328,
         "eurostat:nuts_2021_id":"FI196",
+        "figov:code":"204",
         "fips:code":"",
         "gn:id":831041,
         "gp:id":29389252,
         "hasc:id":"FI.",
+        "iso:code":"FI-17",
         "unlc:id":"FI-17",
         "wd:id":"Q5709"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"6c868446dfaaeb5352c61be6ccefab5e",
     "wof:hierarchy":[
@@ -396,7 +402,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493268,
+    "wof:lastmodified":1695885219,
     "wof:name":"Satakunta",
     "wof:parent_id":404227405,
     "wof:placetype":"region",

--- a/data/856/830/99/85683099.geojson
+++ b/data/856/830/99/85683099.geojson
@@ -372,13 +372,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28325,
         "eurostat:nuts_2021_id":"FI197",
+        "figov:code":"406",
         "fips:code":"",
         "gn:id":830704,
         "gp:id":29389248,
         "hasc:id":"FI.",
+        "iso:code":"FI-11",
         "unlc:id":"FI-11",
         "wd:id":"Q5701"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"ac83338d60f2b2e94d9b69ecd68e7fd2",
     "wof:hierarchy":[
@@ -399,7 +405,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884321,
     "wof:name":"Pirkanmaa",
     "wof:parent_id":404227417,
     "wof:placetype":"region",

--- a/data/856/831/03/85683103.geojson
+++ b/data/856/831/03/85683103.geojson
@@ -375,13 +375,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28313,
         "eurostat:nuts_2021_id":"FI1C5",
+        "figov:code":"109",
         "fips:code":"",
         "gn:id":830699,
         "gp:id":29389253,
         "hasc:id":"FI.",
+        "iso:code":"FI-02",
         "unlc:id":"FI-02",
         "wd:id":"Q5691"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"635948abf699552a08f26eecb389f335",
     "wof:hierarchy":[
@@ -402,7 +408,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493269,
+    "wof:lastmodified":1695885220,
     "wof:name":"South Karelia",
     "wof:parent_id":404227411,
     "wof:placetype":"region",

--- a/data/856/831/09/85683109.geojson
+++ b/data/856/831/09/85683109.geojson
@@ -349,13 +349,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28318,
         "eurostat:nuts_2021_id":"FI1D1",
+        "figov:code":"310",
         "fips:code":"",
         "gn:id":830695,
         "gp:id":29389260,
         "hasc:id":"FI.",
+        "iso:code":"FI-04",
         "unlc:id":"FI-04",
         "wd:id":"Q5693"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"86703f2e180f4c697e2bf674cdbb0c84",
     "wof:hierarchy":[
@@ -376,7 +382,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493269,
+    "wof:lastmodified":1695885220,
     "wof:name":"Southern Savonia",
     "wof:parent_id":404227407,
     "wof:placetype":"region",

--- a/data/856/831/13/85683113.geojson
+++ b/data/856/831/13/85683113.geojson
@@ -364,13 +364,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28322,
         "eurostat:nuts_2021_id":"FI194",
+        "figov:code":"414",
         "fips:code":"",
         "gn:id":830682,
         "gp:id":29389256,
         "hasc:id":"FI.",
+        "iso:code":"FI-03",
         "unlc:id":"FI-03",
         "wd:id":"Q5692"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"b2bed2cd4ee3676a43495fe5c1e60b3e",
     "wof:hierarchy":[
@@ -391,7 +397,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493271,
+    "wof:lastmodified":1695885222,
     "wof:name":"Southern Ostrobothnia",
     "wof:parent_id":404227417,
     "wof:placetype":"region",

--- a/data/856/831/17/85683117.geojson
+++ b/data/856/831/17/85683117.geojson
@@ -370,12 +370,18 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28324,
         "eurostat:nuts_2021_id":"FI193",
+        "figov:code":"413",
         "fips:code":"",
         "gn:id":830685,
         "gp:id":29389258,
         "hasc:id":"FI.",
+        "iso:code":"FI-08",
         "wd:id":"Q5697"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"20da2a15211323b5e8b34ed0bd5545c9",
     "wof:hierarchy":[
@@ -396,7 +402,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493272,
+    "wof:lastmodified":1695885222,
     "wof:name":"Central Finland",
     "wof:parent_id":404227417,
     "wof:placetype":"region",

--- a/data/856/831/19/85683119.geojson
+++ b/data/856/831/19/85683119.geojson
@@ -352,12 +352,18 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28326,
         "eurostat:nuts_2021_id":"FI195",
+        "figov:code":"415",
         "fips:code":"",
         "gn:id":830676,
         "gp:id":29389259,
         "hasc:id":"FI.",
+        "iso:code":"FI-12",
         "wd:id":"Q5702"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"e732f77720305246db5102eb978a5433",
     "wof:hierarchy":[
@@ -378,7 +384,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493272,
+    "wof:lastmodified":1695885223,
     "wof:name":"Ostrobothnia",
     "wof:parent_id":404227417,
     "wof:placetype":"region",

--- a/data/856/831/25/85683125.geojson
+++ b/data/856/831/25/85683125.geojson
@@ -365,13 +365,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28323,
         "eurostat:nuts_2021_id":"FI1D5",
+        "figov:code":"416",
         "fips:code":"",
         "gn:id":830675,
         "gp:id":29389257,
         "hasc:id":"FI.",
+        "iso:code":"FI-07",
         "unlc:id":"FI-07",
         "wd:id":"Q5696"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"b2aad7aef6edbebef23cf9c90157a5ba",
     "wof:hierarchy":[
@@ -392,7 +398,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493273,
+    "wof:lastmodified":1695885224,
     "wof:name":"Central Ostrobothnia",
     "wof:parent_id":404227417,
     "wof:placetype":"region",

--- a/data/856/831/31/85683131.geojson
+++ b/data/856/831/31/85683131.geojson
@@ -374,13 +374,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28320,
         "eurostat:nuts_2021_id":"FI1D2",
+        "figov:code":"311",
         "fips:code":"",
         "gn:id":830690,
         "gp:id":29389262,
         "hasc:id":"FI.",
+        "iso:code":"FI-15",
         "unlc:id":"FI-15",
         "wd:id":"Q5706"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"965de59a6cbb892f2d4a7f858efa639a",
     "wof:hierarchy":[
@@ -401,7 +407,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493273,
+    "wof:lastmodified":1695885224,
     "wof:name":"Northern Savonia",
     "wof:parent_id":404227407,
     "wof:placetype":"region",

--- a/data/856/831/33/85683133.geojson
+++ b/data/856/831/33/85683133.geojson
@@ -387,13 +387,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28319,
         "eurostat:nuts_2021_id":"FI1D3",
+        "figov:code":"312",
         "fips:code":"",
         "gn:id":830686,
         "gp:id":29389261,
         "hasc:id":"FI.",
+        "iso:code":"FI-13",
         "unlc:id":"FI-13",
         "wd:id":"Q5703"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"de9348e2f78ddd796b546d49752ce51b",
     "wof:hierarchy":[
@@ -414,7 +420,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493274,
+    "wof:lastmodified":1695885225,
     "wof:name":"North Karelen",
     "wof:parent_id":404227407,
     "wof:placetype":"region",

--- a/data/856/831/37/85683137.geojson
+++ b/data/856/831/37/85683137.geojson
@@ -369,13 +369,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28330,
         "eurostat:nuts_2021_id":"FI1D8",
+        "figov:code":"518",
         "fips:code":"",
         "gn:id":830664,
         "gp:id":29389264,
         "hasc:id":"FI.",
+        "iso:code":"FI-05",
         "unlc:id":"FI-05",
         "wd:id":"Q5694"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes"
@@ -399,7 +405,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493275,
+    "wof:lastmodified":1695885226,
     "wof:name":"Kainuu",
     "wof:parent_id":404227415,
     "wof:placetype":"region",

--- a/data/856/831/43/85683143.geojson
+++ b/data/856/831/43/85683143.geojson
@@ -382,13 +382,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28327,
         "eurostat:nuts_2021_id":"FI1D9",
+        "figov:code":"517",
         "fips:code":"",
         "gn:id":830667,
         "gp:id":29389265,
         "hasc:id":"FI.",
+        "iso:code":"FI-14",
         "unlc:id":"FI-14",
         "wd:id":"Q5704"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes"
@@ -412,7 +418,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493276,
+    "wof:lastmodified":1695885226,
     "wof:name":"Northern Ostrobothnia",
     "wof:parent_id":404227415,
     "wof:placetype":"region",

--- a/data/856/831/47/85683147.geojson
+++ b/data/856/831/47/85683147.geojson
@@ -378,13 +378,19 @@
     "wof:concordances":{
         "digitalenvoy:region_code":28321,
         "eurostat:nuts_2021_id":"FI1D7",
+        "figov:code":"619",
         "fips:code":"",
         "gn:id":830603,
         "gp:id":12577870,
         "hasc:id":"FI.",
+        "iso:code":"FI-10",
         "unlc:id":"FI-10",
         "wd:id":"Q5700"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         404227409
     ],
@@ -408,7 +414,7 @@
         "fin",
         "swe"
     ],
-    "wof:lastmodified":1694493276,
+    "wof:lastmodified":1695885227,
     "wof:name":"Lapland",
     "wof:parent_id":404227409,
     "wof:placetype":"region",

--- a/data/907/198/465/907198465.geojson
+++ b/data/907/198/465/907198465.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -180,8 +183,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_766",
-        "eurostat:nuts_2021_id":"766"
+        "eurostat:nuts_2021_id":"766",
+        "figov:code":"766",
+        "figov:id":"au205725"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"29fa1d7c6ab861daa02f2765c9e084a8",
     "wof:hierarchy":[
@@ -196,7 +205,7 @@
         }
     ],
     "wof:id":907198465,
-    "wof:lastmodified":1684352510,
+    "wof:lastmodified":1695877718,
     "wof:name":"Sottunga",
     "wof:parent_id":1159321503,
     "wof:placetype":"localadmin",

--- a/data/907/198/469/907198469.geojson
+++ b/data/907/198/469/907198469.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -172,10 +175,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_434",
         "eurostat:nuts_2021_id":"434",
+        "figov:code":"434",
+        "figov:id":"au206776",
         "gn:id":647572,
         "gp:id":12591007,
         "qs_pg:id":1026800
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -193,7 +202,7 @@
         }
     ],
     "wof:id":907198469,
-    "wof:lastmodified":1684352510,
+    "wof:lastmodified":1695877718,
     "wof:name":"Loviisa",
     "wof:parent_id":1159321525,
     "wof:placetype":"localadmin",

--- a/data/907/198/473/907198473.geojson
+++ b/data/907/198/473/907198473.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -65,8 +68,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_043",
-        "eurostat:nuts_2021_id":"043"
+        "eurostat:nuts_2021_id":"043",
+        "figov:code":"043",
+        "figov:id":"au219323"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"85a2ec02b3e9510d7668d5434ed7858d",
     "wof:hierarchy":[
@@ -80,7 +89,7 @@
         }
     ],
     "wof:id":907198473,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877718,
     "wof:name":"Eckero",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/907/198/477/907198477.geojson
+++ b/data/907/198/477/907198477.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,8 +141,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_076",
-        "eurostat:nuts_2021_id":"076"
+        "eurostat:nuts_2021_id":"076",
+        "figov:code":"076",
+        "figov:id":"au219344"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"6457e7892418280dba8896133a5c8708",
     "wof:hierarchy":[
@@ -154,7 +163,7 @@
         }
     ],
     "wof:id":907198477,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877719,
     "wof:name":"Hammarland",
     "wof:parent_id":1159321611,
     "wof:placetype":"localadmin",

--- a/data/907/198/483/907198483.geojson
+++ b/data/907/198/483/907198483.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -168,8 +171,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_417",
-        "eurostat:nuts_2021_id":"417"
+        "eurostat:nuts_2021_id":"417",
+        "figov:code":"417",
+        "figov:id":"au219486"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"e94ca1143b3ce4eeb2be303551b96b33",
     "wof:hierarchy":[
@@ -184,7 +193,7 @@
         }
     ],
     "wof:id":907198483,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877719,
     "wof:name":"Lemland",
     "wof:parent_id":1159321611,
     "wof:placetype":"localadmin",

--- a/data/907/198/485/907198485.geojson
+++ b/data/907/198/485/907198485.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -66,8 +69,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_062",
-        "eurostat:nuts_2021_id":"062"
+        "eurostat:nuts_2021_id":"062",
+        "figov:code":"062",
+        "figov:id":"au219817"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"e811eb6bb17699ba382de64de5a57dbb",
     "wof:hierarchy":[
@@ -82,7 +91,7 @@
         }
     ],
     "wof:id":907198485,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877719,
     "wof:name":"Foglo",
     "wof:parent_id":1159321503,
     "wof:placetype":"localadmin",

--- a/data/907/198/489/907198489.geojson
+++ b/data/907/198/489/907198489.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -168,8 +171,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_170",
-        "eurostat:nuts_2021_id":"170"
+        "eurostat:nuts_2021_id":"170",
+        "figov:code":"170",
+        "figov:id":"au222036"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"1b1680c2a1bffbc4e44854daf5aae63d",
     "wof:hierarchy":[
@@ -184,7 +193,7 @@
         }
     ],
     "wof:id":907198489,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877719,
     "wof:name":"Jomala",
     "wof:parent_id":1159321611,
     "wof:placetype":"localadmin",

--- a/data/907/198/491/907198491.geojson
+++ b/data/907/198/491/907198491.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -161,8 +164,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_438",
-        "eurostat:nuts_2021_id":"438"
+        "eurostat:nuts_2021_id":"438",
+        "figov:code":"438",
+        "figov:id":"au222172"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"585cccc5da86190684bd42ea6ca0d3c0",
     "wof:hierarchy":[
@@ -176,7 +185,7 @@
         }
     ],
     "wof:id":907198491,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877720,
     "wof:name":"Lumparland",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/907/198/495/907198495.geojson
+++ b/data/907/198/495/907198495.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -86,8 +89,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_941",
-        "eurostat:nuts_2021_id":"941"
+        "eurostat:nuts_2021_id":"941",
+        "figov:code":"941",
+        "figov:id":"au222688"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"1e2158974b35028082f1ffa403e3f9e4",
     "wof:hierarchy":[
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":907198495,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877720,
     "wof:name":"Vardo",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/907/198/499/907198499.geojson
+++ b/data/907/198/499/907198499.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,8 +123,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_771",
-        "eurostat:nuts_2021_id":"771"
+        "eurostat:nuts_2021_id":"771",
+        "figov:code":"771",
+        "figov:id":"au223416"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"546fc21be3afb6a42b80c727b288a1c1",
     "wof:hierarchy":[
@@ -135,7 +144,7 @@
         }
     ],
     "wof:id":907198499,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877720,
     "wof:name":"Sund",
     "wof:parent_id":85667867,
     "wof:placetype":"localadmin",

--- a/data/907/198/503/907198503.geojson
+++ b/data/907/198/503/907198503.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -110,8 +113,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_065",
-        "eurostat:nuts_2021_id":"065"
+        "eurostat:nuts_2021_id":"065",
+        "figov:code":"065",
+        "figov:id":"au223867"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"66326c8eed30afa1cec6b403661ae1af",
     "wof:hierarchy":[
@@ -125,7 +134,7 @@
         }
     ],
     "wof:id":907198503,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877720,
     "wof:name":"Geta",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/907/198/505/907198505.geojson
+++ b/data/907/198/505/907198505.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -180,10 +183,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_078",
         "eurostat:nuts_2021_id":"078",
+        "figov:code":"078",
+        "figov:id":"au224714",
         "gn:id":659102,
         "gp:id":12590992,
         "qs_pg:id":1026815
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -201,7 +210,7 @@
         }
     ],
     "wof:id":907198505,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877720,
     "wof:name":"Hanko",
     "wof:parent_id":1159321627,
     "wof:placetype":"localadmin",

--- a/data/907/198/509/907198509.geojson
+++ b/data/907/198/509/907198509.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -81,10 +84,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_149",
         "eurostat:nuts_2021_id":"149",
+        "figov:code":"149",
+        "figov:id":"au226825",
         "gn:id":656653,
         "gp:id":12590995,
         "qs_pg:id":1030121
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":907198509,
-    "wof:lastmodified":1684352511,
+    "wof:lastmodified":1695877720,
     "wof:name":"Inkoo",
     "wof:parent_id":1159321627,
     "wof:placetype":"localadmin",

--- a/data/907/198/511/907198511.geojson
+++ b/data/907/198/511/907198511.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -162,10 +165,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_257",
         "eurostat:nuts_2021_id":"257",
+        "figov:code":"257",
+        "figov:id":"au229566",
         "gn:id":649630,
         "gp:id":12591002,
         "qs_pg:id":248709
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -183,7 +192,7 @@
         }
     ],
     "wof:id":907198511,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877720,
     "wof:name":"Kirkkonummi",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/517/907198517.geojson
+++ b/data/907/198/517/907198517.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -315,9 +318,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_049",
         "eurostat:nuts_2021_id":"049",
+        "figov:code":"049",
+        "figov:id":"au232492",
         "gn:id":660129,
         "qs_pg:id":206202
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:coterminous":[
         101748415
     ],
@@ -338,7 +347,7 @@
         }
     ],
     "wof:id":907198517,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877720,
     "wof:name":"Espoo",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/521/907198521.geojson
+++ b/data/907/198/521/907198521.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -139,10 +142,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_753",
         "eurostat:nuts_2021_id":"753",
+        "figov:code":"753",
+        "figov:id":"au237168",
         "gn:id":637068,
         "gp:id":12591021,
         "qs_pg:id":1153736
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -160,7 +169,7 @@
         }
     ],
     "wof:id":907198521,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877721,
     "wof:name":"Sipoo",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/525/907198525.geojson
+++ b/data/907/198/525/907198525.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -246,10 +249,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_638",
         "eurostat:nuts_2021_id":"638",
+        "figov:code":"638",
+        "figov:id":"au239574",
         "gn:id":660561,
         "gp:id":12591016,
         "qs_pg:id":248346
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -267,7 +276,7 @@
         }
     ],
     "wof:id":907198525,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877721,
     "wof:name":"Porvoo",
     "wof:parent_id":1159321593,
     "wof:placetype":"localadmin",

--- a/data/907/198/529/907198529.geojson
+++ b/data/907/198/529/907198529.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -66,8 +69,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_060",
-        "eurostat:nuts_2021_id":"060"
+        "eurostat:nuts_2021_id":"060",
+        "figov:code":"060",
+        "figov:id":"au239594"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"ac19c77409552bd41b2aec2b06c68b7c",
     "wof:hierarchy":[
@@ -81,7 +90,7 @@
         }
     ],
     "wof:id":907198529,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877721,
     "wof:name":"Finstrom",
     "wof:parent_id":85667835,
     "wof:placetype":"localadmin",

--- a/data/907/198/535/907198535.geojson
+++ b/data/907/198/535/907198535.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -131,8 +134,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_736",
-        "eurostat:nuts_2021_id":"736"
+        "eurostat:nuts_2021_id":"736",
+        "figov:code":"736",
+        "figov:id":"au240565"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"a0d839de5a3f8390caef25e451f64ef1",
     "wof:hierarchy":[
@@ -146,7 +155,7 @@
         }
     ],
     "wof:id":907198535,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877721,
     "wof:name":"Saltvik",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/907/198/539/907198539.geojson
+++ b/data/907/198/539/907198539.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -162,9 +165,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_224",
         "eurostat:nuts_2021_id":"224",
+        "figov:code":"224",
+        "figov:id":"au246554",
         "gn:id":653961,
         "qs_pg:id":244408
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -182,7 +191,7 @@
         }
     ],
     "wof:id":907198539,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877722,
     "wof:name":"Karkkila",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/543/907198543.geojson
+++ b/data/907/198/543/907198543.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_018",
         "eurostat:nuts_2021_id":"018",
+        "figov:code":"018",
+        "figov:id":"au248100",
         "gn:id":660932,
         "gp:id":12590990,
         "qs_pg:id":369929
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907198543,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877722,
     "wof:name":"Askola",
     "wof:parent_id":1159321593,
     "wof:placetype":"localadmin",

--- a/data/907/198/545/907198545.geojson
+++ b/data/907/198/545/907198545.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,9 +135,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_611",
         "eurostat:nuts_2021_id":"611",
+        "figov:code":"611",
+        "figov:id":"au248686",
         "gn:id":640974,
         "qs_pg:id":1030021
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -152,7 +161,7 @@
         }
     ],
     "wof:id":907198545,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877722,
     "wof:name":"Pornainen",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/549/907198549.geojson
+++ b/data/907/198/549/907198549.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -150,10 +153,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_761",
         "eurostat:nuts_2021_id":"761",
+        "figov:code":"761",
+        "figov:id":"au253897",
         "gn:id":636347,
         "gp:id":12590974,
         "qs_pg:id":550546
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -171,7 +180,7 @@
         }
     ],
     "wof:id":907198549,
-    "wof:lastmodified":1684352512,
+    "wof:lastmodified":1695877722,
     "wof:name":"Somero",
     "wof:parent_id":1159321585,
     "wof:placetype":"localadmin",

--- a/data/907/198/555/907198555.geojson
+++ b/data/907/198/555/907198555.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -96,8 +99,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_035",
-        "eurostat:nuts_2021_id":"035"
+        "eurostat:nuts_2021_id":"035",
+        "figov:code":"035",
+        "figov:id":"au254219"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"f991c1b06f846194e67bc7accf683a7d",
     "wof:hierarchy":[
@@ -112,7 +121,7 @@
         }
     ],
     "wof:id":907198555,
-    "wof:lastmodified":1684352513,
+    "wof:lastmodified":1695877723,
     "wof:name":"Brando",
     "wof:parent_id":1159321503,
     "wof:placetype":"localadmin",

--- a/data/907/198/557/907198557.geojson
+++ b/data/907/198/557/907198557.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_505",
         "eurostat:nuts_2021_id":"505",
+        "figov:code":"505",
+        "figov:id":"au258425",
         "gn:id":646709,
         "gp:id":12591008,
         "qs_pg:id":1026798
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198557,
-    "wof:lastmodified":1684352513,
+    "wof:lastmodified":1695877723,
     "wof:name":"Mantsala",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/561/907198561.geojson
+++ b/data/907/198/561/907198561.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_086",
         "eurostat:nuts_2021_id":"086",
+        "figov:code":"086",
+        "figov:id":"au262046",
         "gn:id":658582,
         "gp:id":12590651,
         "qs_pg:id":369918
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198561,
-    "wof:lastmodified":1684352513,
+    "wof:lastmodified":1695877723,
     "wof:name":"Hausjarvi",
     "wof:parent_id":1159321541,
     "wof:placetype":"localadmin",

--- a/data/907/198/567/907198567.geojson
+++ b/data/907/198/567/907198567.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_316",
         "eurostat:nuts_2021_id":"316",
+        "figov:code":"316",
+        "figov:id":"au263792",
         "gn:id":653953,
         "gp:id":12590661,
         "qs_pg:id":244406
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198567,
-    "wof:lastmodified":1684352513,
+    "wof:lastmodified":1695877724,
     "wof:name":"Karkola",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/573/907198573.geojson
+++ b/data/907/198/573/907198573.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,9 +132,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_433",
         "eurostat:nuts_2021_id":"433",
+        "figov:code":"433",
+        "figov:id":"au266868",
         "gn:id":647662,
         "qs_pg:id":1026801
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907198573,
-    "wof:lastmodified":1684352513,
+    "wof:lastmodified":1695877724,
     "wof:name":"Loppi",
     "wof:parent_id":1159321541,
     "wof:placetype":"localadmin",

--- a/data/907/198/577/907198577.geojson
+++ b/data/907/198/577/907198577.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,9 +150,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_560",
         "eurostat:nuts_2021_id":"560",
+        "figov:code":"560",
+        "figov:id":"au271214",
         "gn:id":643645,
         "qs_pg:id":1026794
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -167,7 +176,7 @@
         }
     ],
     "wof:id":907198577,
-    "wof:lastmodified":1684352513,
+    "wof:lastmodified":1695877724,
     "wof:name":"Orimattila",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/581/907198581.geojson
+++ b/data/907/198/581/907198581.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -81,9 +84,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_834",
         "eurostat:nuts_2021_id":"834",
+        "figov:code":"834",
+        "figov:id":"au273730",
         "gn:id":634996,
         "qs_pg:id":81312
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":907198581,
-    "wof:lastmodified":1684352514,
+    "wof:lastmodified":1695877725,
     "wof:name":"Tammela",
     "wof:parent_id":1159321511,
     "wof:placetype":"localadmin",

--- a/data/907/198/585/907198585.geojson
+++ b/data/907/198/585/907198585.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_098",
         "eurostat:nuts_2021_id":"098",
+        "figov:code":"098",
+        "figov:id":"au277898",
         "gn:id":657530,
         "gp:id":12590653,
         "qs_pg:id":1316645
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907198585,
-    "wof:lastmodified":1684352514,
+    "wof:lastmodified":1695877726,
     "wof:name":"Hollola",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/595/907198595.geojson
+++ b/data/907/198/595/907198595.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -141,10 +144,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_927",
         "eurostat:nuts_2021_id":"927",
+        "figov:code":"927",
+        "figov:id":"au280184",
         "gn:id":631707,
         "gp:id":12591026,
         "qs_pg:id":248707
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -162,7 +171,7 @@
         }
     ],
     "wof:id":907198595,
-    "wof:lastmodified":1684352515,
+    "wof:lastmodified":1695877727,
     "wof:name":"Vihti",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/599/907198599.geojson
+++ b/data/907/198/599/907198599.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -108,10 +111,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_543",
         "eurostat:nuts_2021_id":"543",
+        "figov:code":"543",
+        "figov:id":"au283021",
         "gn:id":644171,
         "gp:id":12591011,
         "qs_pg:id":248708
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -129,7 +138,7 @@
         }
     ],
     "wof:id":907198599,
-    "wof:lastmodified":1684352515,
+    "wof:lastmodified":1695877727,
     "wof:name":"Nurmijarvi",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/603/907198603.geojson
+++ b/data/907/198/603/907198603.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,9 +75,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_106",
         "eurostat:nuts_2021_id":"106",
+        "figov:code":"106",
+        "figov:id":"au284094",
         "gp:id":12590994,
         "qs_pg:id":221870
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":907198603,
-    "wof:lastmodified":1684352515,
+    "wof:lastmodified":1695877727,
     "wof:name":"Hyvinkaa",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/607/907198607.geojson
+++ b/data/907/198/607/907198607.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -81,10 +84,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_407",
         "eurostat:nuts_2021_id":"407",
+        "figov:code":"407",
+        "figov:id":"au287172",
         "gn:id":648976,
         "gp:id":12591003,
         "qs_pg:id":493008
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":907198607,
-    "wof:lastmodified":1684352515,
+    "wof:lastmodified":1695877728,
     "wof:name":"Lapinjarvi",
     "wof:parent_id":1159321525,
     "wof:placetype":"localadmin",

--- a/data/907/198/611/907198611.geojson
+++ b/data/907/198/611/907198611.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_304",
         "eurostat:nuts_2021_id":"304",
+        "figov:code":"304",
+        "figov:id":"au287983",
         "gn:id":650000,
         "gp:id":12590931,
         "qs_pg:id":1026810
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907198611,
-    "wof:lastmodified":1684352515,
+    "wof:lastmodified":1695877728,
     "wof:name":"Kustavi",
     "wof:parent_id":1159321637,
     "wof:placetype":"localadmin",

--- a/data/907/198/615/907198615.geojson
+++ b/data/907/198/615/907198615.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -198,10 +201,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_895",
         "eurostat:nuts_2021_id":"895",
+        "figov:code":"895",
+        "figov:id":"au292519",
         "gn:id":633222,
         "gp:id":12590981,
         "qs_pg:id":81291
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -219,7 +228,7 @@
         }
     ],
     "wof:id":907198615,
-    "wof:lastmodified":1684352515,
+    "wof:lastmodified":1695877728,
     "wof:name":"Uusikaupunki",
     "wof:parent_id":1159321637,
     "wof:placetype":"localadmin",

--- a/data/907/198/619/907198619.geojson
+++ b/data/907/198/619/907198619.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_142",
         "eurostat:nuts_2021_id":"142",
+        "figov:code":"142",
+        "figov:id":"au299103",
         "gn:id":656808,
         "gp:id":12590756,
         "qs_pg:id":81498
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907198619,
-    "wof:lastmodified":1684352516,
+    "wof:lastmodified":1695877729,
     "wof:name":"Iitti",
     "wof:parent_id":1159321557,
     "wof:placetype":"localadmin",

--- a/data/907/198/627/907198627.geojson
+++ b/data/907/198/627/907198627.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -183,10 +186,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_245",
         "eurostat:nuts_2021_id":"245",
+        "figov:code":"245",
+        "figov:id":"au300829",
         "gn:id":653186,
         "gp:id":12591001,
         "qs_pg:id":1062313
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -204,7 +213,7 @@
         }
     ],
     "wof:id":907198627,
-    "wof:lastmodified":1684352516,
+    "wof:lastmodified":1695877730,
     "wof:name":"Kerava",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/631/907198631.geojson
+++ b/data/907/198/631/907198631.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -177,10 +180,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_858",
         "eurostat:nuts_2021_id":"858",
+        "figov:code":"858",
+        "figov:id":"au304337",
         "gn:id":633592,
         "gp:id":12591024,
         "qs_pg:id":349780
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -198,7 +207,7 @@
         }
     ],
     "wof:id":907198631,
-    "wof:lastmodified":1684352516,
+    "wof:lastmodified":1695877730,
     "wof:name":"Tuusula",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/635/907198635.geojson
+++ b/data/907/198/635/907198635.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,9 +129,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_833",
         "eurostat:nuts_2021_id":"833",
+        "figov:code":"833",
+        "figov:id":"au305093",
         "gn:id":635133,
         "qs_pg:id":81313
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -146,7 +155,7 @@
         }
     ],
     "wof:id":907198635,
-    "wof:lastmodified":1684352517,
+    "wof:lastmodified":1695877730,
     "wof:name":"Taivassalo",
     "wof:parent_id":1159321637,
     "wof:placetype":"localadmin",

--- a/data/907/198/639/907198639.geojson
+++ b/data/907/198/639/907198639.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,9 +75,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_186",
         "eurostat:nuts_2021_id":"186",
+        "figov:code":"186",
+        "figov:id":"au306074",
         "gp:id":12590996,
         "qs_pg:id":1153737
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":907198639,
-    "wof:lastmodified":1684352517,
+    "wof:lastmodified":1695877730,
     "wof:name":"Jarvenpaa",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/643/907198643.geojson
+++ b/data/907/198/643/907198643.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_918",
         "eurostat:nuts_2021_id":"918",
+        "figov:code":"918",
+        "figov:id":"au312640",
         "gn:id":632062,
         "gp:id":12590986,
         "qs_pg:id":245059
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907198643,
-    "wof:lastmodified":1684352517,
+    "wof:lastmodified":1695877731,
     "wof:name":"Vehmaa",
     "wof:parent_id":1159321637,
     "wof:placetype":"localadmin",

--- a/data/907/198/647/907198647.geojson
+++ b/data/907/198/647/907198647.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -267,10 +270,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_398",
         "eurostat:nuts_2021_id":"398",
+        "figov:code":"398",
+        "figov:id":"au313801",
         "gn:id":649374,
         "gp:id":12590667,
         "qs_pg:id":81426
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -288,7 +297,7 @@
         }
     ],
     "wof:id":907198647,
-    "wof:lastmodified":1684352517,
+    "wof:lastmodified":1695877731,
     "wof:name":"Lahti",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/651/907198651.geojson
+++ b/data/907/198/651/907198651.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -84,10 +87,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_624",
         "eurostat:nuts_2021_id":"624",
+        "figov:code":"624",
+        "figov:id":"au320359",
         "gn:id":640385,
         "gp:id":12590768,
         "qs_pg:id":1117603
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":907198651,
-    "wof:lastmodified":1684352517,
+    "wof:lastmodified":1695877731,
     "wof:name":"Pyhtaa",
     "wof:parent_id":1159321573,
     "wof:placetype":"localadmin",

--- a/data/907/198/655/907198655.geojson
+++ b/data/907/198/655/907198655.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -200,10 +203,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_444",
         "eurostat:nuts_2021_id":"444",
+        "figov:code":"444",
+        "figov:id":"au322405",
         "gn:id":647752,
         "gp:id":12591005,
         "qs_pg:id":1062305
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -221,7 +230,7 @@
         }
     ],
     "wof:id":907198655,
-    "wof:lastmodified":1684352517,
+    "wof:lastmodified":1695877731,
     "wof:name":"Lohja",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/663/907198663.geojson
+++ b/data/907/198/663/907198663.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_616",
         "eurostat:nuts_2021_id":"616",
+        "figov:code":"616",
+        "figov:id":"au322821",
         "gn:id":640753,
         "gp:id":12591018,
         "qs_pg:id":1030019
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907198663,
-    "wof:lastmodified":1684352518,
+    "wof:lastmodified":1695877732,
     "wof:name":"Pukkila",
     "wof:parent_id":1159321593,
     "wof:placetype":"localadmin",

--- a/data/907/198/665/907198665.geojson
+++ b/data/907/198/665/907198665.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -136,9 +139,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_684",
         "eurostat:nuts_2021_id":"684",
+        "figov:code":"684",
+        "figov:id":"au325067",
         "gn:id":639735,
         "qs_pg:id":845224
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907198665,
-    "wof:lastmodified":1684352518,
+    "wof:lastmodified":1695877732,
     "wof:name":"Rauma",
     "wof:parent_id":1159321607,
     "wof:placetype":"localadmin",

--- a/data/907/198/669/907198669.geojson
+++ b/data/907/198/669/907198669.geojson
@@ -11,7 +11,7 @@
     "figov:national_code":"51",
     "figov:swe_type":"Kommun",
     "geom:area":0.107647,
-    "geom:area_square_m":640012709.021893,
+    "geom:area_square_m":640012709.021884,
     "geom:bbox":"20.8120814968,61.1381352141,21.9459419575,61.352649806",
     "geom:latitude":61.260836,
     "geom:longitude":21.470857,
@@ -21,6 +21,9 @@
     ],
     "label:fin_x_preferred_placetype":[
         "kunta"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:swe_x_preferred_placetype":[
         "kommun"
@@ -110,15 +113,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "figov:code":"051",
+        "figov:id":"au327808",
         "gn:id":660074,
         "gp:id":12590908,
         "qs_pg:id":1030126
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
     ],
-    "wof:geomhash":"d3b1d827710c56766fdc073916300814",
+    "wof:geomhash":"f7c5ed4cfa70ea61063784455adae62b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -131,7 +140,7 @@
         }
     ],
     "wof:id":907198669,
-    "wof:lastmodified":1582312053,
+    "wof:lastmodified":1695877713,
     "wof:name":"Eurajoki",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/198/671/907198671.geojson
+++ b/data/907/198/671/907198671.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_400",
         "eurostat:nuts_2021_id":"400",
+        "figov:code":"400",
+        "figov:id":"au332524",
         "gn:id":649307,
         "gp:id":12590933,
         "qs_pg:id":369899
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907198671,
-    "wof:lastmodified":1684352518,
+    "wof:lastmodified":1695877732,
     "wof:name":"Laitila",
     "wof:parent_id":1159321637,
     "wof:placetype":"localadmin",

--- a/data/907/198/675/907198675.geojson
+++ b/data/907/198/675/907198675.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_631",
         "eurostat:nuts_2021_id":"631",
+        "figov:code":"631",
+        "figov:id":"au333003",
         "gn:id":640406,
         "gp:id":12590964,
         "qs_pg:id":81352
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198675,
-    "wof:lastmodified":1684352518,
+    "wof:lastmodified":1695877733,
     "wof:name":"Pyharanta",
     "wof:parent_id":1159321637,
     "wof:placetype":"localadmin",

--- a/data/907/198/681/907198681.geojson
+++ b/data/907/198/681/907198681.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,9 +81,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_504",
         "eurostat:nuts_2021_id":"504",
+        "figov:code":"504",
+        "figov:id":"au333129",
         "gn:id":645234,
         "qs_pg:id":81397
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":907198681,
-    "wof:lastmodified":1684352518,
+    "wof:lastmodified":1695877733,
     "wof:name":"Myrskyla",
     "wof:parent_id":1159321593,
     "wof:placetype":"localadmin",

--- a/data/907/198/683/907198683.geojson
+++ b/data/907/198/683/907198683.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -222,9 +225,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_285",
         "eurostat:nuts_2021_id":"285",
+        "figov:code":"285",
+        "figov:id":"au336953",
         "gn:id":650950,
         "qs_pg:id":81446
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -242,7 +251,7 @@
         }
     ],
     "wof:id":907198683,
-    "wof:lastmodified":1684352518,
+    "wof:lastmodified":1695877733,
     "wof:name":"Kotka",
     "wof:parent_id":1159321573,
     "wof:placetype":"localadmin",

--- a/data/907/198/689/907198689.geojson
+++ b/data/907/198/689/907198689.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -162,10 +165,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_111",
         "eurostat:nuts_2021_id":"111",
+        "figov:code":"111",
+        "figov:id":"au347865",
         "gn:id":658292,
         "gp:id":12590807,
         "qs_pg:id":1026812
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -183,7 +192,7 @@
         }
     ],
     "wof:id":907198689,
-    "wof:lastmodified":1684352518,
+    "wof:lastmodified":1695877733,
     "wof:name":"Heinola",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/691/907198691.geojson
+++ b/data/907/198/691/907198691.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_016",
         "eurostat:nuts_2021_id":"016",
+        "figov:code":"016",
+        "figov:id":"au349641",
         "gn:id":660951,
         "gp:id":12590645,
         "qs_pg:id":81534
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907198691,
-    "wof:lastmodified":1684352519,
+    "wof:lastmodified":1695877734,
     "wof:name":"Asikkala",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/699/907198699.geojson
+++ b/data/907/198/699/907198699.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_435",
         "eurostat:nuts_2021_id":"435",
+        "figov:code":"435",
+        "figov:id":"au351122",
         "gn:id":647523,
         "gp:id":12590717,
         "qs_pg:id":81411
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907198699,
-    "wof:lastmodified":1684352519,
+    "wof:lastmodified":1695877735,
     "wof:name":"Luhanka",
     "wof:parent_id":1159321619,
     "wof:placetype":"localadmin",

--- a/data/907/198/701/907198701.geojson
+++ b/data/907/198/701/907198701.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_781",
         "eurostat:nuts_2021_id":"781",
+        "figov:code":"781",
+        "figov:id":"au352923",
         "gn:id":635337,
         "gp:id":12590829,
         "qs_pg:id":81315
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198701,
-    "wof:lastmodified":1684352519,
+    "wof:lastmodified":1695877735,
     "wof:name":"Sysma",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/705/907198705.geojson
+++ b/data/907/198/705/907198705.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_531",
         "eurostat:nuts_2021_id":"531",
+        "figov:code":"531",
+        "figov:id":"au355960",
         "gn:id":645150,
         "gp:id":12590950,
         "qs_pg:id":1030065
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907198705,
-    "wof:lastmodified":1684352519,
+    "wof:lastmodified":1695877735,
     "wof:name":"Nakkila",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/198/709/907198709.geojson
+++ b/data/907/198/709/907198709.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_755",
         "eurostat:nuts_2021_id":"755",
+        "figov:code":"755",
+        "figov:id":"au355966",
         "gn:id":636608,
         "gp:id":12591022,
         "qs_pg:id":926550
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907198709,
-    "wof:lastmodified":1684352519,
+    "wof:lastmodified":1695877735,
     "wof:name":"Siuntio",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/198/715/907198715.geojson
+++ b/data/907/198/715/907198715.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_576",
         "eurostat:nuts_2021_id":"576",
+        "figov:code":"576",
+        "figov:id":"au357532",
         "gn:id":643261,
         "gp:id":12590678,
         "qs_pg:id":369866
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907198715,
-    "wof:lastmodified":1684352520,
+    "wof:lastmodified":1695877735,
     "wof:name":"Padasjoki",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/719/907198719.geojson
+++ b/data/907/198/719/907198719.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_935",
         "eurostat:nuts_2021_id":"935",
+        "figov:code":"935",
+        "figov:id":"au359338",
         "gn:id":631390,
         "gp:id":12590778,
         "qs_pg:id":1026778
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907198719,
-    "wof:lastmodified":1684352520,
+    "wof:lastmodified":1695877736,
     "wof:name":"Virolahti",
     "wof:parent_id":1159321573,
     "wof:placetype":"localadmin",

--- a/data/907/198/721/907198721.geojson
+++ b/data/907/198/721/907198721.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_507",
         "eurostat:nuts_2021_id":"507",
+        "figov:code":"507",
+        "figov:id":"au366842",
         "gn:id":646699,
         "gp:id":12590816,
         "qs_pg:id":1008268
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198721,
-    "wof:lastmodified":1684352520,
+    "wof:lastmodified":1695877736,
     "wof:name":"Mantyharju",
     "wof:parent_id":1159321539,
     "wof:placetype":"localadmin",

--- a/data/907/198/727/907198727.geojson
+++ b/data/907/198/727/907198727.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -192,10 +195,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_260",
         "eurostat:nuts_2021_id":"260",
+        "figov:code":"260",
+        "figov:id":"au372040",
         "gn:id":652615,
         "gp:id":12590889,
         "qs_pg:id":1027247
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -213,7 +222,7 @@
         }
     ],
     "wof:id":907198727,
-    "wof:lastmodified":1684352520,
+    "wof:lastmodified":1695877737,
     "wof:name":"Kitee",
     "wof:parent_id":1159321517,
     "wof:placetype":"localadmin",

--- a/data/907/198/735/907198735.geojson
+++ b/data/907/198/735/907198735.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_922",
         "eurostat:nuts_2021_id":"922",
+        "figov:code":"922",
+        "figov:id":"au379987",
         "gn:id":631857,
         "gp:id":12590692,
         "qs_pg:id":1029966
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907198735,
-    "wof:lastmodified":1684352521,
+    "wof:lastmodified":1695877738,
     "wof:name":"Vesilahti",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/198/737/907198737.geojson
+++ b/data/907/198/737/907198737.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_489",
         "eurostat:nuts_2021_id":"489",
+        "figov:code":"489",
+        "figov:id":"au381494",
         "gn:id":646080,
         "gp:id":12590766,
         "qs_pg:id":81405
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198737,
-    "wof:lastmodified":1684352521,
+    "wof:lastmodified":1695877738,
     "wof:name":"Miehikkala",
     "wof:parent_id":1159321573,
     "wof:placetype":"localadmin",

--- a/data/907/198/739/907198739.geojson
+++ b/data/907/198/739/907198739.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_081",
         "eurostat:nuts_2021_id":"081",
+        "figov:code":"081",
+        "figov:id":"au383725",
         "gn:id":658759,
         "gp:id":12590804,
         "qs_pg:id":369923
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907198739,
-    "wof:lastmodified":1684352521,
+    "wof:lastmodified":1695877738,
     "wof:name":"Hartola",
     "wof:parent_id":1159321483,
     "wof:placetype":"localadmin",

--- a/data/907/198/743/907198743.geojson
+++ b/data/907/198/743/907198743.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_588",
         "eurostat:nuts_2021_id":"588",
+        "figov:code":"588",
+        "figov:id":"au392975",
         "gn:id":642077,
         "gp:id":12590819,
         "qs_pg:id":225393
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907198743,
-    "wof:lastmodified":1684352522,
+    "wof:lastmodified":1695877739,
     "wof:name":"Pertunmaa",
     "wof:parent_id":1159321539,
     "wof:placetype":"localadmin",

--- a/data/907/198/751/907198751.geojson
+++ b/data/907/198/751/907198751.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_172",
         "eurostat:nuts_2021_id":"172",
+        "figov:code":"172",
+        "figov:id":"au400668",
         "gn:id":655582,
         "gp:id":12590703,
         "qs_pg:id":1151722
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907198751,
-    "wof:lastmodified":1684352522,
+    "wof:lastmodified":1695877740,
     "wof:name":"Joutsa",
     "wof:parent_id":1159321619,
     "wof:placetype":"localadmin",

--- a/data/907/198/755/907198755.geojson
+++ b/data/907/198/755/907198755.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_097",
         "eurostat:nuts_2021_id":"097",
+        "figov:code":"097",
+        "figov:id":"au401004",
         "gn:id":657731,
         "gp:id":12590809,
         "qs_pg:id":274933
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907198755,
-    "wof:lastmodified":1684352522,
+    "wof:lastmodified":1695877741,
     "wof:name":"Hirvensalmi",
     "wof:parent_id":1159321539,
     "wof:placetype":"localadmin",

--- a/data/907/198/757/907198757.geojson
+++ b/data/907/198/757/907198757.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,9 +132,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_623",
         "eurostat:nuts_2021_id":"623",
+        "figov:code":"623",
+        "figov:id":"au404835",
         "gn:id":640505,
         "qs_pg:id":276085
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907198757,
-    "wof:lastmodified":1684352523,
+    "wof:lastmodified":1695877741,
     "wof:name":"Puumala",
     "wof:parent_id":1159321539,
     "wof:placetype":"localadmin",

--- a/data/907/198/759/907198759.geojson
+++ b/data/907/198/759/907198759.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_739",
         "eurostat:nuts_2021_id":"739",
+        "figov:code":"739",
+        "figov:id":"au407751",
         "gn:id":637312,
         "gp:id":12590772,
         "qs_pg:id":953624
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907198759,
-    "wof:lastmodified":1684352523,
+    "wof:lastmodified":1695877742,
     "wof:name":"Savitaipale",
     "wof:parent_id":1159321547,
     "wof:placetype":"localadmin",

--- a/data/907/198/761/907198761.geojson
+++ b/data/907/198/761/907198761.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_178",
         "eurostat:nuts_2021_id":"178",
+        "figov:code":"178",
+        "figov:id":"au410625",
         "gn:id":655257,
         "gp:id":12590812,
         "qs_pg:id":1151727
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907198761,
-    "wof:lastmodified":1684352523,
+    "wof:lastmodified":1695877742,
     "wof:name":"Juva",
     "wof:parent_id":1159321615,
     "wof:placetype":"localadmin",

--- a/data/907/198/765/907198765.geojson
+++ b/data/907/198/765/907198765.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -256,10 +259,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_491",
         "eurostat:nuts_2021_id":"491",
+        "figov:code":"491",
+        "figov:id":"au412816",
         "gn:id":646006,
         "gp:id":12590817,
         "qs_pg:id":1062304
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -277,7 +286,7 @@
         }
     ],
     "wof:id":907198765,
-    "wof:lastmodified":1684352524,
+    "wof:lastmodified":1695877743,
     "wof:name":"Mikkeli",
     "wof:parent_id":1159321539,
     "wof:placetype":"localadmin",

--- a/data/907/198/773/907198773.geojson
+++ b/data/907/198/773/907198773.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_213",
         "eurostat:nuts_2021_id":"213",
+        "figov:code":"213",
+        "figov:id":"au416175",
         "gn:id":654408,
         "gp:id":12590814,
         "qs_pg:id":244410
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907198773,
-    "wof:lastmodified":1684352524,
+    "wof:lastmodified":1695877744,
     "wof:name":"Kangasniemi",
     "wof:parent_id":1159321539,
     "wof:placetype":"localadmin",

--- a/data/907/198/779/907198779.geojson
+++ b/data/907/198/779/907198779.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_831",
         "eurostat:nuts_2021_id":"831",
+        "figov:code":"831",
+        "figov:id":"au417811",
         "gn:id":635150,
         "gp:id":12590774,
         "qs_pg:id":953623
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907198779,
-    "wof:lastmodified":1684352525,
+    "wof:lastmodified":1695877745,
     "wof:name":"Taipalsaari",
     "wof:parent_id":1159321547,
     "wof:placetype":"localadmin",

--- a/data/907/198/787/907198787.geojson
+++ b/data/907/198/787/907198787.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,9 +123,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_768",
         "eurostat:nuts_2021_id":"768",
+        "figov:code":"768",
+        "figov:id":"au419534",
         "gp:id":12590828,
         "qs_pg:id":1292954
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -140,7 +149,7 @@
         }
     ],
     "wof:id":907198787,
-    "wof:lastmodified":1684352525,
+    "wof:lastmodified":1695877745,
     "wof:name":"Sulkava",
     "wof:parent_id":1159321493,
     "wof:placetype":"localadmin",

--- a/data/907/198/791/907198791.geojson
+++ b/data/907/198/791/907198791.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_700",
         "eurostat:nuts_2021_id":"700",
+        "figov:code":"700",
+        "figov:id":"au422817",
         "gn:id":638804,
         "gp:id":12590770,
         "qs_pg:id":81342
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907198791,
-    "wof:lastmodified":1684352525,
+    "wof:lastmodified":1695877746,
     "wof:name":"Ruokolahti",
     "wof:parent_id":1159321507,
     "wof:placetype":"localadmin",

--- a/data/907/198/797/907198797.geojson
+++ b/data/907/198/797/907198797.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_484",
         "eurostat:nuts_2021_id":"484",
+        "figov:code":"484",
+        "figov:id":"au429150",
         "gn:id":646193,
         "gp:id":12590944,
         "qs_pg:id":1151720
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907198797,
-    "wof:lastmodified":1684352525,
+    "wof:lastmodified":1695877746,
     "wof:name":"Merikarvia",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/198/799/907198799.geojson
+++ b/data/907/198/799/907198799.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_291",
         "eurostat:nuts_2021_id":"291",
+        "figov:code":"291",
+        "figov:id":"au431701",
         "gn:id":650704,
         "gp:id":12590713,
         "qs_pg:id":274927
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907198799,
-    "wof:lastmodified":1684352525,
+    "wof:lastmodified":1695877746,
     "wof:name":"Kuhmoinen",
     "wof:parent_id":1159321587,
     "wof:placetype":"localadmin",

--- a/data/907/198/805/907198805.geojson
+++ b/data/907/198/805/907198805.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_689",
         "eurostat:nuts_2021_id":"689",
+        "figov:code":"689",
+        "figov:id":"au432919",
         "gn:id":639672,
         "gp:id":12590769,
         "qs_pg:id":31715
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198805,
-    "wof:lastmodified":1684352526,
+    "wof:lastmodified":1695877746,
     "wof:name":"Rautjarvi",
     "wof:parent_id":1159321507,
     "wof:placetype":"localadmin",

--- a/data/907/198/809/907198809.geojson
+++ b/data/907/198/809/907198809.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_747",
         "eurostat:nuts_2021_id":"747",
+        "figov:code":"747",
+        "figov:id":"au434607",
         "gn:id":637020,
         "gp:id":12590973,
         "qs_pg:id":202557
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907198809,
-    "wof:lastmodified":1684352526,
+    "wof:lastmodified":1695877747,
     "wof:name":"Siikainen",
     "wof:parent_id":1159321519,
     "wof:placetype":"localadmin",

--- a/data/907/198/813/907198813.geojson
+++ b/data/907/198/813/907198813.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_850",
         "eurostat:nuts_2021_id":"850",
+        "figov:code":"850",
+        "figov:id":"au436678",
         "gn:id":634298,
         "gp:id":12590726,
         "qs_pg:id":244400
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907198813,
-    "wof:lastmodified":1684352526,
+    "wof:lastmodified":1695877747,
     "wof:name":"Toivakka",
     "wof:parent_id":1159321625,
     "wof:placetype":"localadmin",

--- a/data/907/198/817/907198817.geojson
+++ b/data/907/198/817/907198817.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_077",
         "eurostat:nuts_2021_id":"077",
+        "figov:code":"077",
+        "figov:id":"au438714",
         "gn:id":659025,
         "gp:id":12590700,
         "qs_pg:id":369927
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907198817,
-    "wof:lastmodified":1684352526,
+    "wof:lastmodified":1695877747,
     "wof:name":"Hankasalmi",
     "wof:parent_id":1159321625,
     "wof:placetype":"localadmin",

--- a/data/907/198/823/907198823.geojson
+++ b/data/907/198/823/907198823.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_608",
         "eurostat:nuts_2021_id":"608",
+        "figov:code":"608",
+        "figov:id":"au438740",
         "gn:id":641045,
         "gp:id":12590960,
         "qs_pg:id":1153733
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907198823,
-    "wof:lastmodified":1684352526,
+    "wof:lastmodified":1695877748,
     "wof:name":"Pomarkku",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/198/827/907198827.geojson
+++ b/data/907/198/827/907198827.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_287",
         "eurostat:nuts_2021_id":"287",
+        "figov:code":"287",
+        "figov:id":"au444380",
         "gn:id":650770,
         "gp:id":12591049,
         "qs_pg:id":81444
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907198827,
-    "wof:lastmodified":1684352526,
+    "wof:lastmodified":1695877748,
     "wof:name":"Kristiinankaupunki",
     "wof:parent_id":1159321495,
     "wof:placetype":"localadmin",

--- a/data/907/198/829/907198829.geojson
+++ b/data/907/198/829/907198829.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -146,6 +149,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_103",
         "eurostat:nuts_2021_id":"103",
+        "figov:code":"103",
+        "figov:id":"au454190",
         "gn:id":657113,
         "gp:id":12590654,
         "qs_pg:id":274931
@@ -154,6 +159,10 @@
         "gn:id":657112,
         "qs_pg:id":896234
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -171,7 +180,7 @@
         }
     ],
     "wof:id":907198829,
-    "wof:lastmodified":1684352527,
+    "wof:lastmodified":1695877748,
     "wof:name":"Humppila",
     "wof:parent_id":1159321511,
     "wof:placetype":"localadmin",

--- a/data/907/198/833/907198833.geojson
+++ b/data/907/198/833/907198833.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,10 +75,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_981",
         "eurostat:nuts_2021_id":"981",
+        "figov:code":"981",
+        "figov:id":"au455176",
         "gn:id":630736,
         "gp:id":12590698,
         "qs_pg:id":276688
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -93,7 +102,7 @@
         }
     ],
     "wof:id":907198833,
-    "wof:lastmodified":1684352527,
+    "wof:lastmodified":1695877749,
     "wof:name":"Ypaja",
     "wof:parent_id":1159321511,
     "wof:placetype":"localadmin",

--- a/data/907/198/835/907198835.geojson
+++ b/data/907/198/835/907198835.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_619",
         "eurostat:nuts_2021_id":"619",
+        "figov:code":"619",
+        "figov:id":"au458257",
         "gn:id":640689,
         "gp:id":12590963,
         "qs_pg:id":1027216
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907198835,
-    "wof:lastmodified":1684352527,
+    "wof:lastmodified":1695877749,
     "wof:name":"Punkalaidun",
     "wof:parent_id":1159321613,
     "wof:placetype":"localadmin",

--- a/data/907/198/841/907198841.geojson
+++ b/data/907/198/841/907198841.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_887",
         "eurostat:nuts_2021_id":"887",
+        "figov:code":"887",
+        "figov:id":"au461973",
         "gn:id":633332,
         "gp:id":12590690,
         "qs_pg:id":474340
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907198841,
-    "wof:lastmodified":1684352527,
+    "wof:lastmodified":1695877749,
     "wof:name":"Urjala",
     "wof:parent_id":1159321621,
     "wof:placetype":"localadmin",

--- a/data/907/198/847/907198847.geojson
+++ b/data/907/198/847/907198847.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_778",
         "eurostat:nuts_2021_id":"778",
+        "figov:code":"778",
+        "figov:id":"au471089",
         "gn:id":635693,
         "gp:id":12590745,
         "qs_pg:id":1026785
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907198847,
-    "wof:lastmodified":1684352527,
+    "wof:lastmodified":1695877750,
     "wof:name":"Suonenjoki",
     "wof:parent_id":1159321623,
     "wof:placetype":"localadmin",

--- a/data/907/198/853/907198853.geojson
+++ b/data/907/198/853/907198853.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_580",
         "eurostat:nuts_2021_id":"580",
+        "figov:code":"580",
+        "figov:id":"au472861",
         "gn:id":642667,
         "gp:id":12590767,
         "qs_pg:id":1026797
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907198853,
-    "wof:lastmodified":1684352528,
+    "wof:lastmodified":1695877751,
     "wof:name":"Parikkala",
     "wof:parent_id":1159321507,
     "wof:placetype":"localadmin",

--- a/data/907/198/859/907198859.geojson
+++ b/data/907/198/859/907198859.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -115,10 +118,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_309",
         "eurostat:nuts_2021_id":"309",
+        "figov:code":"309",
+        "figov:id":"au475063",
         "gn:id":830266,
         "gp:id":12590894,
         "qs_pg:id":554291
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -136,7 +145,7 @@
         }
     ],
     "wof:id":907198859,
-    "wof:lastmodified":1684352528,
+    "wof:lastmodified":1695877751,
     "wof:name":"Outokumpu",
     "wof:parent_id":1159321551,
     "wof:placetype":"localadmin",

--- a/data/907/198/863/907198863.geojson
+++ b/data/907/198/863/907198863.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_426",
         "eurostat:nuts_2021_id":"426",
+        "figov:code":"426",
+        "figov:id":"au477825",
         "gn:id":647852,
         "gp:id":12590892,
         "qs_pg:id":369894
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907198863,
-    "wof:lastmodified":1684352528,
+    "wof:lastmodified":1695877752,
     "wof:name":"Liperi",
     "wof:parent_id":1159321551,
     "wof:placetype":"localadmin",

--- a/data/907/198/867/907198867.geojson
+++ b/data/907/198/867/907198867.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -202,10 +205,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_740",
         "eurostat:nuts_2021_id":"740",
+        "figov:code":"740",
+        "figov:id":"au480246",
         "gn:id":637293,
         "gp:id":56071674,
         "qs_pg:id":1026786
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -223,7 +232,7 @@
         }
     ],
     "wof:id":907198867,
-    "wof:lastmodified":1684352529,
+    "wof:lastmodified":1695877753,
     "wof:name":"Savonlinna",
     "wof:parent_id":1159321493,
     "wof:placetype":"localadmin",

--- a/data/907/198/871/907198871.geojson
+++ b/data/907/198/871/907198871.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_151",
         "eurostat:nuts_2021_id":"151",
+        "figov:code":"151",
+        "figov:id":"au482317",
         "gn:id":656518,
         "gp:id":12591035,
         "qs_pg:id":81494
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907198871,
-    "wof:lastmodified":1684352531,
+    "wof:lastmodified":1695877757,
     "wof:name":"Isojoki",
     "wof:parent_id":1159321543,
     "wof:placetype":"localadmin",

--- a/data/907/198/873/907198873.geojson
+++ b/data/907/198/873/907198873.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,9 +132,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_099",
         "eurostat:nuts_2021_id":"099",
+        "figov:code":"099",
+        "figov:id":"au484671",
         "gn:id":657480,
         "qs_pg:id":1026816
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907198873,
-    "wof:lastmodified":1684352531,
+    "wof:lastmodified":1695877757,
     "wof:name":"Honkajoki",
     "wof:parent_id":1159321519,
     "wof:placetype":"localadmin",

--- a/data/907/198/879/907198879.geojson
+++ b/data/907/198/879/907198879.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_171",
         "eurostat:nuts_2021_id":"171",
+        "figov:code":"171",
+        "figov:id":"au487152",
         "gn:id":655627,
         "gp:id":12590811,
         "qs_pg:id":1272762
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907198879,
-    "wof:lastmodified":1684352531,
+    "wof:lastmodified":1695877757,
     "wof:name":"Joroinen",
     "wof:parent_id":1159321615,
     "wof:placetype":"localadmin",

--- a/data/907/198/885/907198885.geojson
+++ b/data/907/198/885/907198885.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,9 +135,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_681",
         "eurostat:nuts_2021_id":"681",
+        "figov:code":"681",
+        "figov:id":"au487760",
         "gn:id":639907,
         "qs_pg:id":1151712
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -152,7 +161,7 @@
         }
     ],
     "wof:id":907198885,
-    "wof:lastmodified":1684352532,
+    "wof:lastmodified":1695877758,
     "wof:name":"Rantasalmi",
     "wof:parent_id":1159321493,
     "wof:placetype":"localadmin",

--- a/data/907/198/887/907198887.geojson
+++ b/data/907/198/887/907198887.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -255,10 +258,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_405",
         "eurostat:nuts_2021_id":"405",
+        "figov:code":"405",
+        "figov:id":"au492955",
         "gn:id":648901,
         "gp:id":12590763,
         "qs_pg:id":81422
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -276,7 +285,7 @@
         }
     ],
     "wof:id":907198887,
-    "wof:lastmodified":1684352532,
+    "wof:lastmodified":1695877759,
     "wof:name":"Lappeenranta",
     "wof:parent_id":1159321547,
     "wof:placetype":"localadmin",

--- a/data/907/198/891/907198891.geojson
+++ b/data/907/198/891/907198891.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_707",
         "eurostat:nuts_2021_id":"707",
+        "figov:code":"707",
+        "figov:id":"au493171",
         "gn:id":640272,
         "gp:id":12590897,
         "qs_pg:id":81350
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198891,
-    "wof:lastmodified":1684352532,
+    "wof:lastmodified":1695877759,
     "wof:name":"Raakkyla",
     "wof:parent_id":1159321517,
     "wof:placetype":"localadmin",

--- a/data/907/198/897/907198897.geojson
+++ b/data/907/198/897/907198897.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,10 +123,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_686",
         "eurostat:nuts_2021_id":"686",
+        "figov:code":"686",
+        "figov:id":"au493872",
         "gn:id":639711,
         "gp:id":12590741,
         "qs_pg:id":1151711
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":907198897,
-    "wof:lastmodified":1684352532,
+    "wof:lastmodified":1695877760,
     "wof:name":"Rautalampi",
     "wof:parent_id":1159321623,
     "wof:placetype":"localadmin",

--- a/data/907/198/899/907198899.geojson
+++ b/data/907/198/899/907198899.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_420",
         "eurostat:nuts_2021_id":"420",
+        "figov:code":"420",
+        "figov:id":"au497623",
         "gn:id":648228,
         "gp:id":12590737,
         "qs_pg:id":1030081
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198899,
-    "wof:lastmodified":1684352532,
+    "wof:lastmodified":1695877760,
     "wof:name":"Leppavirta",
     "wof:parent_id":1159321629,
     "wof:placetype":"localadmin",

--- a/data/907/198/905/907198905.geojson
+++ b/data/907/198/905/907198905.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -160,9 +163,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_886",
         "eurostat:nuts_2021_id":"886",
+        "figov:code":"886",
+        "figov:id":"au502555",
         "gn:id":633396,
         "qs_pg:id":369827
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -180,7 +189,7 @@
         }
     ],
     "wof:id":907198905,
-    "wof:lastmodified":1684352533,
+    "wof:lastmodified":1695877761,
     "wof:name":"Ulvila",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/198/907/907198907.geojson
+++ b/data/907/198/907/907198907.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_503",
         "eurostat:nuts_2021_id":"503",
+        "figov:code":"503",
+        "figov:id":"au506681",
         "gn:id":645243,
         "gp:id":12590948,
         "qs_pg:id":1227169
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198907,
-    "wof:lastmodified":1684352533,
+    "wof:lastmodified":1695877761,
     "wof:name":"Mynamaki",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/909/907198909.geojson
+++ b/data/907/198/909/907198909.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -360,10 +363,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_853",
         "eurostat:nuts_2021_id":"853",
+        "figov:code":"853",
+        "figov:id":"au516331",
         "gn:id":633680,
         "gp:id":12590979,
         "qs_pg:id":81302
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:coterminous":[
         101748421
     ],
@@ -384,7 +393,7 @@
         }
     ],
     "wof:id":907198909,
-    "wof:lastmodified":1684352533,
+    "wof:lastmodified":1695877761,
     "wof:name":"Turku",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/913/907198913.geojson
+++ b/data/907/198/913/907198913.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -177,10 +180,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_529",
         "eurostat:nuts_2021_id":"529",
+        "figov:code":"529",
+        "figov:id":"au517702",
         "gn:id":645212,
         "gp:id":12590949,
         "qs_pg:id":1062303
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -198,7 +207,7 @@
         }
     ],
     "wof:id":907198913,
-    "wof:lastmodified":1684352533,
+    "wof:lastmodified":1695877762,
     "wof:name":"Naantali",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/915/907198915.geojson
+++ b/data/907/198/915/907198915.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_050",
         "eurostat:nuts_2021_id":"050",
+        "figov:code":"050",
+        "figov:id":"au519108",
         "gn:id":660080,
         "gp:id":12590907,
         "qs_pg:id":1030143
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907198915,
-    "wof:lastmodified":1684352533,
+    "wof:lastmodified":1695877762,
     "wof:name":"Eura",
     "wof:parent_id":1159321607,
     "wof:placetype":"localadmin",

--- a/data/907/198/919/907198919.geojson
+++ b/data/907/198/919/907198919.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_481",
         "eurostat:nuts_2021_id":"481",
+        "figov:code":"481",
+        "figov:id":"au521949",
         "gn:id":646487,
         "gp:id":12590942,
         "qs_pg:id":1242922
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907198919,
-    "wof:lastmodified":1684352533,
+    "wof:lastmodified":1695877762,
     "wof:name":"Masku",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/921/907198921.geojson
+++ b/data/907/198/921/907198921.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_636",
         "eurostat:nuts_2021_id":"636",
+        "figov:code":"636",
+        "figov:id":"au527857",
         "gn:id":640829,
         "gp:id":12590962,
         "qs_pg:id":1030022
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907198921,
-    "wof:lastmodified":1684352534,
+    "wof:lastmodified":1695877762,
     "wof:name":"Poytya",
     "wof:parent_id":1159321505,
     "wof:placetype":"localadmin",

--- a/data/907/198/923/907198923.geojson
+++ b/data/907/198/923/907198923.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_561",
         "eurostat:nuts_2021_id":"561",
+        "figov:code":"561",
+        "figov:id":"au530194",
         "gn:id":643641,
         "gp:id":12590954,
         "qs_pg:id":369881
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907198923,
-    "wof:lastmodified":1684352534,
+    "wof:lastmodified":1695877763,
     "wof:name":"Oripaa",
     "wof:parent_id":1159321505,
     "wof:placetype":"localadmin",

--- a/data/907/198/925/907198925.geojson
+++ b/data/907/198/925/907198925.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_783",
         "eurostat:nuts_2021_id":"783",
+        "figov:code":"783",
+        "figov:id":"au534843",
         "gn:id":638105,
         "gp:id":12590969,
         "qs_pg:id":1026783
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907198925,
-    "wof:lastmodified":1684352534,
+    "wof:lastmodified":1695877763,
     "wof:name":"Sakyla",
     "wof:parent_id":1159321607,
     "wof:placetype":"localadmin",

--- a/data/907/198/927/907198927.geojson
+++ b/data/907/198/927/907198927.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_079",
         "eurostat:nuts_2021_id":"079",
+        "figov:code":"079",
+        "figov:id":"au537510",
         "gn:id":658921,
         "gp:id":12590910,
         "qs_pg:id":337788
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907198927,
-    "wof:lastmodified":1684352534,
+    "wof:lastmodified":1695877763,
     "wof:name":"Harjavalta",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/198/933/907198933.geojson
+++ b/data/907/198/933/907198933.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -173,10 +176,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_102",
         "eurostat:nuts_2021_id":"102",
+        "figov:code":"102",
+        "figov:id":"au540821",
         "gn:id":657181,
         "gp:id":12590913,
         "qs_pg:id":274932
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -194,7 +203,7 @@
         }
     ],
     "wof:id":907198933,
-    "wof:lastmodified":1684352534,
+    "wof:lastmodified":1695877763,
     "wof:name":"Huittinen",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/198/937/907198937.geojson
+++ b/data/907/198/937/907198937.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_271",
         "eurostat:nuts_2021_id":"271",
+        "figov:code":"271",
+        "figov:id":"au542010",
         "gn:id":651981,
         "qs_pg:id":81452
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907198937,
-    "wof:lastmodified":1684352534,
+    "wof:lastmodified":1695877764,
     "wof:name":"Kokemaki",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/198/941/907198941.geojson
+++ b/data/907/198/941/907198941.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,9 +129,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_738",
         "eurostat:nuts_2021_id":"738",
+        "figov:code":"738",
+        "figov:id":"au544049",
         "gn:id":637401,
         "qs_pg:id":81333
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -146,7 +155,7 @@
         }
     ],
     "wof:id":907198941,
-    "wof:lastmodified":1684352534,
+    "wof:lastmodified":1695877764,
     "wof:name":"Sauvo",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/943/907198943.geojson
+++ b/data/907/198/943/907198943.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -165,10 +168,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_734",
         "eurostat:nuts_2021_id":"734",
+        "figov:code":"734",
+        "figov:id":"au546210",
         "gn:id":637948,
         "gp:id":12590970,
         "qs_pg:id":834923
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -186,7 +195,7 @@
         }
     ],
     "wof:id":907198943,
-    "wof:lastmodified":1684352535,
+    "wof:lastmodified":1695877764,
     "wof:name":"Salo",
     "wof:parent_id":1159321585,
     "wof:placetype":"localadmin",

--- a/data/907/198/951/907198951.geojson
+++ b/data/907/198/951/907198951.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_169",
         "eurostat:nuts_2021_id":"169",
+        "figov:code":"169",
+        "figov:id":"au548052",
         "gn:id":655693,
         "gp:id":12590657,
         "qs_pg:id":231148
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907198951,
-    "wof:lastmodified":1684352535,
+    "wof:lastmodified":1695877765,
     "wof:name":"Jokioinen",
     "wof:parent_id":1159321511,
     "wof:placetype":"localadmin",

--- a/data/907/198/953/907198953.geojson
+++ b/data/907/198/953/907198953.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_441",
         "eurostat:nuts_2021_id":"441",
+        "figov:code":"441",
+        "figov:id":"au550075",
         "gn:id":647289,
         "qs_pg:id":81410
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907198953,
-    "wof:lastmodified":1684352535,
+    "wof:lastmodified":1695877765,
     "wof:name":"Luumaki",
     "wof:parent_id":1159321547,
     "wof:placetype":"localadmin",

--- a/data/907/198/955/907198955.geojson
+++ b/data/907/198/955/907198955.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,9 +132,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_538",
         "eurostat:nuts_2021_id":"538",
+        "figov:code":"538",
+        "figov:id":"au552605",
         "gn:id":644328,
         "qs_pg:id":1030072
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907198955,
-    "wof:lastmodified":1684352535,
+    "wof:lastmodified":1695877766,
     "wof:name":"Nousiainen",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/957/907198957.geojson
+++ b/data/907/198/957/907198957.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -174,10 +177,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_680",
         "eurostat:nuts_2021_id":"680",
+        "figov:code":"680",
+        "figov:id":"au552655",
         "gn:id":640125,
         "gp:id":12590965,
         "qs_pg:id":349797
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -195,7 +204,7 @@
         }
     ],
     "wof:id":907198957,
-    "wof:lastmodified":1684352535,
+    "wof:lastmodified":1695877766,
     "wof:name":"Raisio",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/959/907198959.geojson
+++ b/data/907/198/959/907198959.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -130,10 +133,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_416",
         "eurostat:nuts_2021_id":"416",
+        "figov:code":"416",
+        "figov:id":"au552666",
         "gn:id":648388,
         "gp:id":12590764,
         "qs_pg:id":1030082
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -151,7 +160,7 @@
         }
     ],
     "wof:id":907198959,
-    "wof:lastmodified":1684352535,
+    "wof:lastmodified":1695877766,
     "wof:name":"Lemi",
     "wof:parent_id":1159321547,
     "wof:placetype":"localadmin",

--- a/data/907/198/963/907198963.geojson
+++ b/data/907/198/963/907198963.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -165,10 +168,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_430",
         "eurostat:nuts_2021_id":"430",
+        "figov:code":"430",
+        "figov:id":"au552672",
         "gn:id":647732,
         "gp:id":12590938,
         "qs_pg:id":1026802
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -186,7 +195,7 @@
         }
     ],
     "wof:id":907198963,
-    "wof:lastmodified":1684352536,
+    "wof:lastmodified":1695877766,
     "wof:name":"Loimaa",
     "wof:parent_id":1159321505,
     "wof:placetype":"localadmin",

--- a/data/907/198/969/907198969.geojson
+++ b/data/907/198/969/907198969.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -213,10 +216,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_286",
         "eurostat:nuts_2021_id":"286",
+        "figov:code":"286",
+        "figov:id":"au555006",
         "gn:id":650861,
         "gp:id":12590761,
         "qs_pg:id":81445
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -234,7 +243,7 @@
         }
     ],
     "wof:id":907198969,
-    "wof:lastmodified":1684352536,
+    "wof:lastmodified":1695877767,
     "wof:name":"Kouvola",
     "wof:parent_id":1159321557,
     "wof:placetype":"localadmin",

--- a/data/907/198/977/907198977.geojson
+++ b/data/907/198/977/907198977.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -201,9 +204,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_153",
         "eurostat:nuts_2021_id":"153",
+        "figov:code":"153",
+        "figov:id":"au555362",
         "gn:id":656689,
         "qs_pg:id":81496
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -221,7 +230,7 @@
         }
     ],
     "wof:id":907198977,
-    "wof:lastmodified":1684352537,
+    "wof:lastmodified":1695877769,
     "wof:name":"Imatra",
     "wof:parent_id":1159321507,
     "wof:placetype":"localadmin",

--- a/data/907/198/981/907198981.geojson
+++ b/data/907/198/981/907198981.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,9 +132,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_704",
         "eurostat:nuts_2021_id":"704",
+        "figov:code":"704",
+        "figov:id":"au556683",
         "gn:id":638671,
         "qs_pg:id":369840
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907198981,
-    "wof:lastmodified":1684352537,
+    "wof:lastmodified":1695877769,
     "wof:name":"Rusko",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/985/907198985.geojson
+++ b/data/907/198/985/907198985.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_499",
         "eurostat:nuts_2021_id":"499",
+        "figov:code":"499",
+        "figov:id":"au563869",
         "gn:id":651301,
         "gp:id":12591062,
         "qs_pg:id":369916
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907198985,
-    "wof:lastmodified":1684352537,
+    "wof:lastmodified":1695877769,
     "wof:name":"Mustasaari",
     "wof:parent_id":1159321501,
     "wof:placetype":"localadmin",

--- a/data/907/198/989/907198989.geojson
+++ b/data/907/198/989/907198989.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,9 +126,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_399",
         "eurostat:nuts_2021_id":"399",
+        "figov:code":"399",
+        "figov:id":"au567597",
         "gn:id":649351,
         "qs_pg:id":1242930
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -143,7 +152,7 @@
         }
     ],
     "wof:id":907198989,
-    "wof:lastmodified":1684352537,
+    "wof:lastmodified":1695877769,
     "wof:name":"Laihia",
     "wof:parent_id":1159321589,
     "wof:placetype":"localadmin",

--- a/data/907/198/993/907198993.geojson
+++ b/data/907/198/993/907198993.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -171,9 +174,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_202",
         "eurostat:nuts_2021_id":"202",
+        "figov:code":"202",
+        "figov:id":"au568827",
         "gn:id":655131,
         "qs_pg:id":349843
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -191,7 +200,7 @@
         }
     ],
     "wof:id":907198993,
-    "wof:lastmodified":1684352537,
+    "wof:lastmodified":1695877770,
     "wof:name":"Kaarina",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/198/997/907198997.geojson
+++ b/data/907/198/997/907198997.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -141,10 +144,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_217",
         "eurostat:nuts_2021_id":"217",
+        "figov:code":"217",
+        "figov:id":"au576590",
         "gn:id":654315,
         "gp:id":12591040,
         "qs_pg:id":81485
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -162,7 +171,7 @@
         }
     ],
     "wof:id":907198997,
-    "wof:lastmodified":1684352537,
+    "wof:lastmodified":1695877770,
     "wof:name":"Kannus",
     "wof:parent_id":1159321609,
     "wof:placetype":"localadmin",

--- a/data/907/198/999/907198999.geojson
+++ b/data/907/198/999/907198999.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -363,10 +366,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_536",
         "eurostat:nuts_2021_id":"536",
+        "figov:code":"536",
+        "figov:id":"au581193",
         "gn:id":644450,
         "gp:id":12590676,
         "qs_pg:id":834814
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -384,7 +393,7 @@
         }
     ],
     "wof:id":907198999,
-    "wof:lastmodified":1684352537,
+    "wof:lastmodified":1695877770,
     "wof:name":"Nokia",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/199/003/907199003.geojson
+++ b/data/907/199/003/907199003.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_145",
         "eurostat:nuts_2021_id":"145",
+        "figov:code":"145",
+        "figov:id":"au590456",
         "gn:id":656740,
         "gp:id":12591034,
         "qs_pg:id":1030122
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907199003,
-    "wof:lastmodified":1684352538,
+    "wof:lastmodified":1695877771,
     "wof:name":"Ilmajoki",
     "wof:parent_id":1159321561,
     "wof:placetype":"localadmin",

--- a/data/907/199/007/907199007.geojson
+++ b/data/907/199/007/907199007.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -141,10 +144,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_301",
         "eurostat:nuts_2021_id":"301",
+        "figov:code":"301",
+        "figov:id":"au593412",
         "gn:id":650098,
         "gp:id":12591052,
         "qs_pg:id":204142
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -162,7 +171,7 @@
         }
     ],
     "wof:id":907199007,
-    "wof:lastmodified":1684352538,
+    "wof:lastmodified":1695877771,
     "wof:name":"Kurikka",
     "wof:parent_id":1159321561,
     "wof:placetype":"localadmin",

--- a/data/907/199/011/907199011.geojson
+++ b/data/907/199/011/907199011.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_423",
         "eurostat:nuts_2021_id":"423",
+        "figov:code":"423",
+        "figov:id":"au598109",
         "gn:id":648057,
         "gp:id":12590937,
         "qs_pg:id":1026804
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907199011,
-    "wof:lastmodified":1684352538,
+    "wof:lastmodified":1695877772,
     "wof:name":"Lieto",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/199/013/907199013.geojson
+++ b/data/907/199/013/907199013.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_593",
         "eurostat:nuts_2021_id":"593",
+        "figov:code":"593",
+        "figov:id":"au599169",
         "gn:id":830268,
         "gp:id":12590821,
         "qs_pg:id":1026832
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199013,
-    "wof:lastmodified":1684352538,
+    "wof:lastmodified":1695877772,
     "wof:name":"Pieksamaki",
     "wof:parent_id":1159321615,
     "wof:placetype":"localadmin",

--- a/data/907/199/021/907199021.geojson
+++ b/data/907/199/021/907199021.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_046",
         "eurostat:nuts_2021_id":"046",
+        "figov:code":"046",
+        "figov:id":"au599558",
         "gn:id":660236,
         "gp:id":12590803,
         "qs_pg:id":81527
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907199021,
-    "wof:lastmodified":1684352539,
+    "wof:lastmodified":1695877774,
     "wof:name":"Enonkoski",
     "wof:parent_id":1159321493,
     "wof:placetype":"localadmin",

--- a/data/907/199/027/907199027.geojson
+++ b/data/907/199/027/907199027.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_090",
         "eurostat:nuts_2021_id":"090",
+        "figov:code":"090",
+        "figov:id":"au599586",
         "gn:id":658319,
         "gp:id":12590806,
         "qs_pg:id":81508
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199027,
-    "wof:lastmodified":1684352540,
+    "wof:lastmodified":1695877776,
     "wof:name":"Heinavesi",
     "wof:parent_id":1159321493,
     "wof:placetype":"localadmin",

--- a/data/907/199/033/907199033.geojson
+++ b/data/907/199/033/907199033.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_280",
         "eurostat:nuts_2021_id":"280",
+        "figov:code":"280",
+        "figov:id":"au608905",
         "gn:id":651297,
         "gp:id":12591047,
         "qs_pg:id":244403
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907199033,
-    "wof:lastmodified":1684352541,
+    "wof:lastmodified":1695877777,
     "wof:name":"Korsnas",
     "wof:parent_id":1159321501,
     "wof:placetype":"localadmin",

--- a/data/907/199/039/907199039.geojson
+++ b/data/907/199/039/907199039.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_231",
         "eurostat:nuts_2021_id":"231",
+        "figov:code":"231",
+        "figov:id":"au608916",
         "gn:id":653760,
         "gp:id":12591042,
         "qs_pg:id":81473
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199039,
-    "wof:lastmodified":1684352541,
+    "wof:lastmodified":1695877777,
     "wof:name":"Kaskinen",
     "wof:parent_id":1159321495,
     "wof:placetype":"localadmin",

--- a/data/907/199/043/907199043.geojson
+++ b/data/907/199/043/907199043.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_475",
         "eurostat:nuts_2021_id":"475",
+        "figov:code":"475",
+        "figov:id":"au610682",
         "gn:id":646875,
         "gp:id":12591060,
         "qs_pg:id":241617
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907199043,
-    "wof:lastmodified":1684352541,
+    "wof:lastmodified":1695877778,
     "wof:name":"Maalahti",
     "wof:parent_id":1159321501,
     "wof:placetype":"localadmin",

--- a/data/907/199/045/907199045.geojson
+++ b/data/907/199/045/907199045.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -117,10 +120,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_893",
         "eurostat:nuts_2021_id":"893",
+        "figov:code":"893",
+        "figov:id":"au618829",
         "gn:id":644100,
         "gp:id":12591076,
         "qs_pg:id":231128
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -138,7 +147,7 @@
         }
     ],
     "wof:id":907199045,
-    "wof:lastmodified":1684352541,
+    "wof:lastmodified":1695877778,
     "wof:name":"Uusikaarlepyy",
     "wof:parent_id":1159321639,
     "wof:placetype":"localadmin",

--- a/data/907/199/049/907199049.geojson
+++ b/data/907/199/049/907199049.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -228,10 +231,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_272",
         "eurostat:nuts_2021_id":"272",
+        "figov:code":"272",
+        "figov:id":"au626370",
         "gn:id":651951,
         "gp:id":12591046,
         "qs_pg:id":244404
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:coterminous":[
         1159321609
     ],
@@ -252,7 +261,7 @@
         }
     ],
     "wof:id":907199049,
-    "wof:lastmodified":1684352541,
+    "wof:lastmodified":1695877778,
     "wof:name":"Kokkola",
     "wof:parent_id":1159321609,
     "wof:placetype":"localadmin",

--- a/data/907/199/053/907199053.geojson
+++ b/data/907/199/053/907199053.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_857",
         "eurostat:nuts_2021_id":"857",
+        "figov:code":"857",
+        "figov:id":"au628941",
         "gn:id":633594,
         "gp:id":12590747,
         "qs_pg:id":244398
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907199053,
-    "wof:lastmodified":1684352542,
+    "wof:lastmodified":1695877778,
     "wof:name":"Tuusniemi",
     "wof:parent_id":1159321579,
     "wof:placetype":"localadmin",

--- a/data/907/199/059/907199059.geojson
+++ b/data/907/199/059/907199059.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -185,6 +188,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_019",
         "eurostat:nuts_2021_id":"019",
+        "figov:code":"019",
+        "figov:id":"au629557",
         "gn:id":660873,
         "gp:id":12590905,
         "qs_pg:id":201267
@@ -193,6 +198,10 @@
         "gn:id":660874,
         "qs_pg:id":1026817
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -210,7 +219,7 @@
         }
     ],
     "wof:id":907199059,
-    "wof:lastmodified":1684352542,
+    "wof:lastmodified":1695877779,
     "wof:name":"Aura",
     "wof:parent_id":1159321505,
     "wof:placetype":"localadmin",

--- a/data/907/199/063/907199063.geojson
+++ b/data/907/199/063/907199063.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -180,10 +183,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_908",
         "eurostat:nuts_2021_id":"908",
+        "figov:code":"908",
+        "figov:id":"au633081",
         "gn:id":632672,
         "gp:id":12590691,
         "qs_pg:id":834830
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -201,7 +210,7 @@
         }
     ],
     "wof:id":907199063,
-    "wof:lastmodified":1684352542,
+    "wof:lastmodified":1695877779,
     "wof:name":"Valkeakoski",
     "wof:parent_id":1159321621,
     "wof:placetype":"localadmin",

--- a/data/907/199/065/907199065.geojson
+++ b/data/907/199/065/907199065.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_218",
         "eurostat:nuts_2021_id":"218",
+        "figov:code":"218",
+        "figov:id":"au638639",
         "gn:id":654076,
         "gp:id":12591041,
         "qs_pg:id":81483
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907199065,
-    "wof:lastmodified":1684352542,
+    "wof:lastmodified":1695877779,
     "wof:name":"Karijoki",
     "wof:parent_id":1159321543,
     "wof:placetype":"localadmin",

--- a/data/907/199/069/907199069.geojson
+++ b/data/907/199/069/907199069.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -82,10 +85,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_598",
         "eurostat:nuts_2021_id":"598",
+        "figov:code":"598",
+        "figov:id":"au647907",
         "gn:id":656131,
         "gp:id":12591069,
         "qs_pg:id":81493
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -103,7 +112,7 @@
         }
     ],
     "wof:id":907199069,
-    "wof:lastmodified":1684352542,
+    "wof:lastmodified":1695877780,
     "wof:name":"Pietarsaari",
     "wof:parent_id":1159321639,
     "wof:placetype":"localadmin",

--- a/data/907/199/075/907199075.geojson
+++ b/data/907/199/075/907199075.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_152",
         "eurostat:nuts_2021_id":"152",
+        "figov:code":"152",
+        "figov:id":"au650388",
         "gn:id":656457,
         "gp:id":12591036,
         "qs_pg:id":276114
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907199075,
-    "wof:lastmodified":1684352542,
+    "wof:lastmodified":1695877780,
     "wof:name":"Isokyro",
     "wof:parent_id":1159321589,
     "wof:placetype":"localadmin",

--- a/data/907/199/079/907199079.geojson
+++ b/data/907/199/079/907199079.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -84,9 +87,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_759",
         "eurostat:nuts_2021_id":"759",
+        "figov:code":"759",
+        "figov:id":"au656811",
         "gn:id":636397,
         "qs_pg:id":550548
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":907199079,
-    "wof:lastmodified":1684352543,
+    "wof:lastmodified":1695877781,
     "wof:name":"Soini",
     "wof:parent_id":1159321567,
     "wof:placetype":"localadmin",

--- a/data/907/199/083/907199083.geojson
+++ b/data/907/199/083/907199083.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_226",
         "eurostat:nuts_2021_id":"226",
+        "figov:code":"226",
+        "figov:id":"au660037",
         "gn:id":653853,
         "gp:id":12590707,
         "qs_pg:id":81476
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907199083,
-    "wof:lastmodified":1684352543,
+    "wof:lastmodified":1695877781,
     "wof:name":"Karstula",
     "wof:parent_id":1159321515,
     "wof:placetype":"localadmin",

--- a/data/907/199/089/907199089.geojson
+++ b/data/907/199/089/907199089.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_989",
         "eurostat:nuts_2021_id":"989",
+        "figov:code":"989",
+        "figov:id":"au663909",
         "gn:id":661897,
         "gp:id":12591027,
         "qs_pg:id":1151735
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199089,
-    "wof:lastmodified":1684352544,
+    "wof:lastmodified":1695877782,
     "wof:name":"Ahtari",
     "wof:parent_id":1159321555,
     "wof:placetype":"localadmin",

--- a/data/907/199/095/907199095.geojson
+++ b/data/907/199/095/907199095.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_495",
         "eurostat:nuts_2021_id":"495",
+        "figov:code":"495",
+        "figov:id":"au667190",
         "gn:id":645711,
         "gp:id":12590718,
         "qs_pg:id":81402
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907199095,
-    "wof:lastmodified":1684352544,
+    "wof:lastmodified":1695877783,
     "wof:name":"Multia",
     "wof:parent_id":1159321499,
     "wof:placetype":"localadmin",

--- a/data/907/199/101/907199101.geojson
+++ b/data/907/199/101/907199101.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_182",
         "eurostat:nuts_2021_id":"182",
+        "figov:code":"182",
+        "figov:id":"au670376",
         "gn:id":656084,
         "gp:id":12590701,
         "qs_pg:id":1151723
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199101,
-    "wof:lastmodified":1684352544,
+    "wof:lastmodified":1695877784,
     "wof:name":"Jamsa",
     "wof:parent_id":1159321587,
     "wof:placetype":"localadmin",

--- a/data/907/199/105/907199105.geojson
+++ b/data/907/199/105/907199105.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_005",
         "eurostat:nuts_2021_id":"005",
+        "figov:code":"005",
+        "figov:id":"au674618",
         "gn:id":661594,
         "gp:id":12591029,
         "qs_pg:id":845301
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199105,
-    "wof:lastmodified":1684352544,
+    "wof:lastmodified":1695877784,
     "wof:name":"Alajarvi",
     "wof:parent_id":1159321567,
     "wof:placetype":"localadmin",

--- a/data/907/199/107/907199107.geojson
+++ b/data/907/199/107/907199107.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_312",
         "eurostat:nuts_2021_id":"312",
+        "figov:code":"312",
+        "figov:id":"au675289",
         "gn:id":649584,
         "gp:id":12590714,
         "qs_pg:id":81427
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199107,
-    "wof:lastmodified":1684352545,
+    "wof:lastmodified":1695877785,
     "wof:name":"Kyyjarvi",
     "wof:parent_id":1159321515,
     "wof:placetype":"localadmin",

--- a/data/907/199/111/907199111.geojson
+++ b/data/907/199/111/907199111.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,10 +123,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_584",
         "eurostat:nuts_2021_id":"584",
+        "figov:code":"584",
+        "figov:id":"au676505",
         "gn:id":642140,
         "gp:id":12591067,
         "qs_pg:id":81371
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":907199111,
-    "wof:lastmodified":1684352545,
+    "wof:lastmodified":1695877785,
     "wof:name":"Perho",
     "wof:parent_id":1159321595,
     "wof:placetype":"localadmin",

--- a/data/907/199/113/907199113.geojson
+++ b/data/907/199/113/907199113.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,9 +132,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_165",
         "eurostat:nuts_2021_id":"165",
+        "figov:code":"165",
+        "figov:id":"au679281",
         "gn:id":656074,
         "qs_pg:id":1026811
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907199113,
-    "wof:lastmodified":1684352545,
+    "wof:lastmodified":1695877786,
     "wof:name":"Janakkala",
     "wof:parent_id":1159321513,
     "wof:placetype":"localadmin",

--- a/data/907/199/119/907199119.geojson
+++ b/data/907/199/119/907199119.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -140,6 +143,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_230",
         "eurostat:nuts_2021_id":"230",
+        "figov:code":"230",
+        "figov:id":"au684790",
         "gn:id":653812,
         "gp:id":12590919,
         "qs_pg:id":201268
@@ -148,6 +153,10 @@
         "gn:id":653814,
         "qs_pg:id":1030094
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907199119,
-    "wof:lastmodified":1684352546,
+    "wof:lastmodified":1695877786,
     "wof:name":"Karvia",
     "wof:parent_id":1159321519,
     "wof:placetype":"localadmin",

--- a/data/907/199/121/907199121.geojson
+++ b/data/907/199/121/907199121.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -162,10 +165,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_232",
         "eurostat:nuts_2021_id":"232",
+        "figov:code":"232",
+        "figov:id":"au687202",
         "gn:id":653628,
         "gp:id":12591043,
         "qs_pg:id":81472
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -183,7 +192,7 @@
         }
     ],
     "wof:id":907199121,
-    "wof:lastmodified":1684352546,
+    "wof:lastmodified":1695877787,
     "wof:name":"Kauhajoki",
     "wof:parent_id":1159321543,
     "wof:placetype":"localadmin",

--- a/data/907/199/125/907199125.geojson
+++ b/data/907/199/125/907199125.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_581",
         "eurostat:nuts_2021_id":"581",
+        "figov:code":"581",
+        "figov:id":"au690078",
         "gn:id":642657,
         "gp:id":12590680,
         "qs_pg:id":235231
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907199125,
-    "wof:lastmodified":1684352546,
+    "wof:lastmodified":1695877787,
     "wof:name":"Parkano",
     "wof:parent_id":1159321533,
     "wof:placetype":"localadmin",

--- a/data/907/199/131/907199131.geojson
+++ b/data/907/199/131/907199131.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_108",
         "eurostat:nuts_2021_id":"108",
+        "figov:code":"108",
+        "figov:id":"au692830",
         "gn:id":659185,
         "qs_pg:id":81520
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907199131,
-    "wof:lastmodified":1684352546,
+    "wof:lastmodified":1695877787,
     "wof:name":"Hameenkyro",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/199/135/907199135.geojson
+++ b/data/907/199/135/907199135.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_601",
         "eurostat:nuts_2021_id":"601",
+        "figov:code":"601",
+        "figov:id":"au695839",
         "gn:id":641661,
         "gp:id":12590721,
         "qs_pg:id":81364
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907199135,
-    "wof:lastmodified":1684352546,
+    "wof:lastmodified":1695877788,
     "wof:name":"Pihtipudas",
     "wof:parent_id":1159321515,
     "wof:placetype":"localadmin",

--- a/data/907/199/139/907199139.geojson
+++ b/data/907/199/139/907199139.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,9 +132,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_256",
         "eurostat:nuts_2021_id":"256",
+        "figov:code":"256",
+        "figov:id":"au696305",
         "gn:id":652746,
         "qs_pg:id":276110
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907199139,
-    "wof:lastmodified":1684352546,
+    "wof:lastmodified":1695877788,
     "wof:name":"Kinnula",
     "wof:parent_id":1159321515,
     "wof:placetype":"localadmin",

--- a/data/907/199/141/907199141.geojson
+++ b/data/907/199/141/907199141.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_691",
         "eurostat:nuts_2021_id":"691",
+        "figov:code":"691",
+        "figov:id":"au698701",
         "gn:id":639578,
         "qs_pg:id":81346
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907199141,
-    "wof:lastmodified":1684352546,
+    "wof:lastmodified":1695877788,
     "wof:name":"Reisjarvi",
     "wof:parent_id":1159321591,
     "wof:placetype":"localadmin",

--- a/data/907/199/147/907199147.geojson
+++ b/data/907/199/147/907199147.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_265",
         "eurostat:nuts_2021_id":"265",
+        "figov:code":"265",
+        "figov:id":"au699536",
         "gn:id":652498,
         "qs_pg:id":81454
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907199147,
-    "wof:lastmodified":1684352547,
+    "wof:lastmodified":1695877788,
     "wof:name":"Kivijarvi",
     "wof:parent_id":1159321515,
     "wof:placetype":"localadmin",

--- a/data/907/199/149/907199149.geojson
+++ b/data/907/199/149/907199149.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -237,10 +240,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_905",
         "eurostat:nuts_2021_id":"905",
+        "figov:code":"905",
+        "figov:id":"au699728",
         "gn:id":632979,
         "gp:id":12591077,
         "qs_pg:id":81288
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -258,7 +267,7 @@
         }
     ],
     "wof:id":907199149,
-    "wof:lastmodified":1684352547,
+    "wof:lastmodified":1695877788,
     "wof:name":"Vaasa",
     "wof:parent_id":1159321501,
     "wof:placetype":"localadmin",

--- a/data/907/199/151/907199151.geojson
+++ b/data/907/199/151/907199151.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_626",
         "eurostat:nuts_2021_id":"626",
+        "figov:code":"626",
+        "figov:id":"au702277",
         "gn:id":640471,
         "gp:id":12590863,
         "qs_pg:id":81355
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199151,
-    "wof:lastmodified":1684352547,
+    "wof:lastmodified":1695877789,
     "wof:name":"Pyhajarvi",
     "wof:parent_id":1159321591,
     "wof:placetype":"localadmin",

--- a/data/907/199/155/907199155.geojson
+++ b/data/907/199/155/907199155.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,10 +75,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_250",
         "eurostat:nuts_2021_id":"250",
+        "figov:code":"250",
+        "figov:id":"au702930",
         "gn:id":652896,
         "gp:id":12590662,
         "qs_pg:id":896233
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -93,7 +102,7 @@
         }
     ],
     "wof:id":907199155,
-    "wof:lastmodified":1684352547,
+    "wof:lastmodified":1695877789,
     "wof:name":"Kihnio",
     "wof:parent_id":1159321533,
     "wof:placetype":"localadmin",

--- a/data/907/199/157/907199157.geojson
+++ b/data/907/199/157/907199157.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -165,10 +168,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_010",
         "eurostat:nuts_2021_id":"010",
+        "figov:code":"010",
+        "figov:id":"au709792",
         "gn:id":661353,
         "gp:id":12591030,
         "qs_pg:id":244412
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -186,7 +195,7 @@
         }
     ],
     "wof:id":907199157,
-    "wof:lastmodified":1684352547,
+    "wof:lastmodified":1695877789,
     "wof:name":"Alavus",
     "wof:parent_id":1159321555,
     "wof:placetype":"localadmin",

--- a/data/907/199/161/907199161.geojson
+++ b/data/907/199/161/907199161.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_599",
         "eurostat:nuts_2021_id":"599",
+        "figov:code":"599",
+        "figov:id":"au710246",
         "gn:id":642456,
         "gp:id":12591068,
         "qs_pg:id":369864
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907199161,
-    "wof:lastmodified":1684352547,
+    "wof:lastmodified":1695877789,
     "wof:name":"Pedersoren kunta",
     "wof:parent_id":1159321639,
     "wof:placetype":"localadmin",

--- a/data/907/199/167/907199167.geojson
+++ b/data/907/199/167/907199167.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,10 +81,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_440",
         "eurostat:nuts_2021_id":"440",
+        "figov:code":"440",
+        "figov:id":"au713427",
         "gn:id":648847,
         "gp:id":12591059,
         "qs_pg:id":232344
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":907199167,
-    "wof:lastmodified":1684352547,
+    "wof:lastmodified":1695877790,
     "wof:name":"Luoto",
     "wof:parent_id":1159321639,
     "wof:placetype":"localadmin",

--- a/data/907/199/171/907199171.geojson
+++ b/data/907/199/171/907199171.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_936",
         "eurostat:nuts_2021_id":"936",
+        "figov:code":"936",
+        "figov:id":"au715134",
         "gn:id":631377,
         "gp:id":12590696,
         "qs_pg:id":1026781
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199171,
-    "wof:lastmodified":1684352548,
+    "wof:lastmodified":1695877791,
     "wof:name":"Virrat",
     "wof:parent_id":1159321485,
     "wof:placetype":"localadmin",

--- a/data/907/199/175/907199175.geojson
+++ b/data/907/199/175/907199175.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_421",
         "eurostat:nuts_2021_id":"421",
+        "figov:code":"421",
+        "figov:id":"au717843",
         "gn:id":648180,
         "qs_pg:id":81417
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907199175,
-    "wof:lastmodified":1684352548,
+    "wof:lastmodified":1695877791,
     "wof:name":"Lestijarvi",
     "wof:parent_id":1159321595,
     "wof:placetype":"localadmin",

--- a/data/907/199/179/907199179.geojson
+++ b/data/907/199/179/907199179.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -169,10 +172,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_249",
         "eurostat:nuts_2021_id":"249",
+        "figov:code":"249",
+        "figov:id":"au719759",
         "gn:id":652978,
         "gp:id":12590708,
         "qs_pg:id":81463
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -190,7 +199,7 @@
         }
     ],
     "wof:id":907199179,
-    "wof:lastmodified":1684352548,
+    "wof:lastmodified":1695877791,
     "wof:name":"Keuruu",
     "wof:parent_id":1159321499,
     "wof:placetype":"localadmin",

--- a/data/907/199/185/907199185.geojson
+++ b/data/907/199/185/907199185.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_211",
         "eurostat:nuts_2021_id":"211",
+        "figov:code":"211",
+        "figov:id":"au724195",
         "gn:id":654441,
         "gp:id":12590660,
         "qs_pg:id":349842
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907199185,
-    "wof:lastmodified":1684352548,
+    "wof:lastmodified":1695877792,
     "wof:name":"Kangasala",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/199/187/907199187.geojson
+++ b/data/907/199/187/907199187.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_635",
         "eurostat:nuts_2021_id":"635",
+        "figov:code":"635",
+        "figov:id":"au725936",
         "gn:id":642977,
         "qs_pg:id":369865
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907199187,
-    "wof:lastmodified":1684352549,
+    "wof:lastmodified":1695877792,
     "wof:name":"Palkane",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/199/197/907199197.geojson
+++ b/data/907/199/197/907199197.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_892",
         "eurostat:nuts_2021_id":"892",
+        "figov:code":"892",
+        "figov:id":"au728420",
         "gn:id":633242,
         "gp:id":12590727,
         "qs_pg:id":232343
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907199197,
-    "wof:lastmodified":1684352549,
+    "wof:lastmodified":1695877793,
     "wof:name":"Uurainen",
     "wof:parent_id":1159321625,
     "wof:placetype":"localadmin",

--- a/data/907/199/203/907199203.geojson
+++ b/data/907/199/203/907199203.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_410",
         "eurostat:nuts_2021_id":"410",
+        "figov:code":"410",
+        "figov:id":"au733507",
         "gn:id":648739,
         "gp:id":12590715,
         "qs_pg:id":1030091
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907199203,
-    "wof:lastmodified":1684352549,
+    "wof:lastmodified":1695877793,
     "wof:name":"Laukaa",
     "wof:parent_id":1159321625,
     "wof:placetype":"localadmin",

--- a/data/907/199/205/907199205.geojson
+++ b/data/907/199/205/907199205.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,10 +123,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_992",
         "eurostat:nuts_2021_id":"992",
+        "figov:code":"992",
+        "figov:id":"au735768",
         "gn:id":662095,
         "gp:id":12590699,
         "qs_pg:id":261989
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":907199205,
-    "wof:lastmodified":1684352549,
+    "wof:lastmodified":1695877793,
     "wof:name":"Aanekoski",
     "wof:parent_id":1159321553,
     "wof:placetype":"localadmin",

--- a/data/907/199/209/907199209.geojson
+++ b/data/907/199/209/907199209.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -170,6 +173,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_577",
         "eurostat:nuts_2021_id":"577",
+        "figov:code":"577",
+        "figov:id":"au737670",
         "gn:id":643154,
         "gp:id":12590955,
         "qs_pg:id":221606
@@ -177,6 +182,10 @@
     "wof:concordances_alt":{
         "qs_pg:id":369862
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -194,7 +203,7 @@
         }
     ],
     "wof:id":907199209,
-    "wof:lastmodified":1684352549,
+    "wof:lastmodified":1695877794,
     "wof:name":"Paimio",
     "wof:parent_id":1159321603,
     "wof:placetype":"localadmin",

--- a/data/907/199/213/907199213.geojson
+++ b/data/907/199/213/907199213.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_729",
         "eurostat:nuts_2021_id":"729",
+        "figov:code":"729",
+        "figov:id":"au738011",
         "gn:id":638390,
         "gp:id":12590723,
         "qs_pg:id":81337
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199213,
-    "wof:lastmodified":1684352549,
+    "wof:lastmodified":1695877794,
     "wof:name":"Saarijarvi",
     "wof:parent_id":1159321515,
     "wof:placetype":"localadmin",

--- a/data/907/199/215/907199215.geojson
+++ b/data/907/199/215/907199215.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_592",
         "eurostat:nuts_2021_id":"592",
+        "figov:code":"592",
+        "figov:id":"au744511",
         "gn:id":641976,
         "gp:id":12590720,
         "qs_pg:id":81369
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199215,
-    "wof:lastmodified":1684352550,
+    "wof:lastmodified":1695877794,
     "wof:name":"Petajavesi",
     "wof:parent_id":1159321625,
     "wof:placetype":"localadmin",

--- a/data/907/199/219/907199219.geojson
+++ b/data/907/199/219/907199219.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_082",
         "eurostat:nuts_2021_id":"082",
+        "figov:code":"082",
+        "figov:id":"au747189",
         "gn:id":658691,
         "gp:id":12590649,
         "qs_pg:id":1026814
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907199219,
-    "wof:lastmodified":1684352550,
+    "wof:lastmodified":1695877795,
     "wof:name":"Hattula",
     "wof:parent_id":1159321513,
     "wof:placetype":"localadmin",

--- a/data/907/199/223/907199223.geojson
+++ b/data/907/199/223/907199223.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -150,10 +153,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_931",
         "eurostat:nuts_2021_id":"931",
+        "figov:code":"931",
+        "figov:id":"au750004",
         "gn:id":631566,
         "gp:id":12590728,
         "qs_pg:id":496472
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -171,7 +180,7 @@
         }
     ],
     "wof:id":907199223,
-    "wof:lastmodified":1684352550,
+    "wof:lastmodified":1695877795,
     "wof:name":"Viitasaari",
     "wof:parent_id":1159321515,
     "wof:placetype":"localadmin",

--- a/data/907/199/227/907199227.geojson
+++ b/data/907/199/227/907199227.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_216",
         "eurostat:nuts_2021_id":"216",
+        "figov:code":"216",
+        "figov:id":"au750010",
         "gn:id":654319,
         "gp:id":12590706,
         "qs_pg:id":244409
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907199227,
-    "wof:lastmodified":1684352550,
+    "wof:lastmodified":1695877795,
     "wof:name":"Kannonkoski",
     "wof:parent_id":1159321515,
     "wof:placetype":"localadmin",

--- a/data/907/199/231/907199231.geojson
+++ b/data/907/199/231/907199231.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -362,6 +365,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_837",
         "eurostat:nuts_2021_id":"837",
+        "figov:code":"837",
+        "figov:id":"au753948",
         "gn:id":634964,
         "gp:id":12590687,
         "qs_pg:id":1092680
@@ -369,6 +374,10 @@
     "wof:concordances_alt":{
         "qs_pg:id":81311
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:coterminous":[
         101748431
     ],
@@ -389,7 +398,7 @@
         }
     ],
     "wof:id":907199231,
-    "wof:lastmodified":1684352550,
+    "wof:lastmodified":1695877796,
     "wof:name":"Tampere",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/199/237/907199237.geojson
+++ b/data/907/199/237/907199237.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -164,6 +167,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_233",
         "eurostat:nuts_2021_id":"233",
+        "figov:code":"233",
+        "figov:id":"au759751",
         "gn:id":653616,
         "gp:id":12591044,
         "qs_pg:id":1008285
@@ -172,6 +177,10 @@
         "gn:id":653617,
         "qs_pg:id":1030093
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -189,7 +198,7 @@
         }
     ],
     "wof:id":907199237,
-    "wof:lastmodified":1684352551,
+    "wof:lastmodified":1695877796,
     "wof:name":"Kauhava",
     "wof:parent_id":1159321561,
     "wof:placetype":"localadmin",

--- a/data/907/199/241/907199241.geojson
+++ b/data/907/199/241/907199241.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -153,10 +156,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_408",
         "eurostat:nuts_2021_id":"408",
+        "figov:code":"408",
+        "figov:id":"au764447",
         "gn:id":648856,
         "gp:id":12591055,
         "qs_pg:id":81420
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -174,7 +183,7 @@
         }
     ],
     "wof:id":907199241,
-    "wof:lastmodified":1684352551,
+    "wof:lastmodified":1695877796,
     "wof:name":"Lapua",
     "wof:parent_id":1159321561,
     "wof:placetype":"localadmin",

--- a/data/907/199/245/907199245.geojson
+++ b/data/907/199/245/907199245.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,9 +75,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_109",
         "eurostat:nuts_2021_id":"109",
+        "figov:code":"109",
+        "figov:id":"au768551",
         "gp:id":12590648,
         "qs_pg:id":1080646
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":907199245,
-    "wof:lastmodified":1684352551,
+    "wof:lastmodified":1695877797,
     "wof:name":"Hameenlinna",
     "wof:parent_id":1159321513,
     "wof:placetype":"localadmin",

--- a/data/907/199/255/907199255.geojson
+++ b/data/907/199/255/907199255.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_403",
         "eurostat:nuts_2021_id":"403",
+        "figov:code":"403",
+        "figov:id":"au770423",
         "gn:id":648923,
         "gp:id":12591054,
         "qs_pg:id":81424
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199255,
-    "wof:lastmodified":1684352552,
+    "wof:lastmodified":1695877799,
     "wof:name":"Lappajarvi",
     "wof:parent_id":1159321567,
     "wof:placetype":"localadmin",

--- a/data/907/199/257/907199257.geojson
+++ b/data/907/199/257/907199257.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_500",
         "eurostat:nuts_2021_id":"500",
+        "figov:code":"500",
+        "figov:id":"au772070",
         "gn:id":645386,
         "gp:id":12590719,
         "qs_pg:id":81399
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907199257,
-    "wof:lastmodified":1684352552,
+    "wof:lastmodified":1695877799,
     "wof:name":"Muurame",
     "wof:parent_id":1159321625,
     "wof:placetype":"localadmin",

--- a/data/907/199/259/907199259.geojson
+++ b/data/907/199/259/907199259.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_480",
         "eurostat:nuts_2021_id":"480",
+        "figov:code":"480",
+        "figov:id":"au778250",
         "gn:id":646519,
         "gp:id":12590941,
         "qs_pg:id":81408
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907199259,
-    "wof:lastmodified":1684352552,
+    "wof:lastmodified":1695877799,
     "wof:name":"Marttila",
     "wof:parent_id":1159321505,
     "wof:placetype":"localadmin",

--- a/data/907/199/263/907199263.geojson
+++ b/data/907/199/263/907199263.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -137,6 +140,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_921",
         "eurostat:nuts_2021_id":"921",
+        "figov:code":"921",
+        "figov:id":"au780942",
         "gn:id":631873,
         "gp:id":12590751,
         "qs_pg:id":1207044
@@ -145,6 +150,10 @@
         "gn:id":631875,
         "qs_pg:id":1029962
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -162,7 +171,7 @@
         }
     ],
     "wof:id":907199263,
-    "wof:lastmodified":1684352552,
+    "wof:lastmodified":1695877800,
     "wof:name":"Vesanto",
     "wof:parent_id":1159321623,
     "wof:placetype":"localadmin",

--- a/data/907/199/265/907199265.geojson
+++ b/data/907/199/265/907199265.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_179",
         "eurostat:nuts_2021_id":"179",
+        "figov:code":"179",
+        "figov:id":"au781192",
         "gn:id":655195,
         "gp:id":12590704,
         "qs_pg:id":496458
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199265,
-    "wof:lastmodified":1684352552,
+    "wof:lastmodified":1695877800,
     "wof:name":"Jyvaskyla",
     "wof:parent_id":1159321625,
     "wof:placetype":"localadmin",

--- a/data/907/199/269/907199269.geojson
+++ b/data/907/199/269/907199269.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_275",
         "eurostat:nuts_2021_id":"275",
+        "figov:code":"275",
+        "figov:id":"au781240",
         "gn:id":651696,
         "gp:id":12590711,
         "qs_pg:id":261988
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907199269,
-    "wof:lastmodified":1684352553,
+    "wof:lastmodified":1695877800,
     "wof:name":"Konnevesi",
     "wof:parent_id":1159321553,
     "wof:placetype":"localadmin",

--- a/data/907/199/273/907199273.geojson
+++ b/data/907/199/273/907199273.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,9 +132,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_934",
         "eurostat:nuts_2021_id":"934",
+        "figov:code":"934",
+        "figov:id":"au781646",
         "gn:id":631449,
         "qs_pg:id":81277
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907199273,
-    "wof:lastmodified":1684352553,
+    "wof:lastmodified":1695877800,
     "wof:name":"Vimpeli",
     "wof:parent_id":1159321567,
     "wof:placetype":"localadmin",

--- a/data/907/199/275/907199275.geojson
+++ b/data/907/199/275/907199275.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_980",
         "eurostat:nuts_2021_id":"980",
+        "figov:code":"980",
+        "figov:id":"au782077",
         "gn:id":630753,
         "gp:id":12590697,
         "qs_pg:id":349779
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199275,
-    "wof:lastmodified":1684352553,
+    "wof:lastmodified":1695877801,
     "wof:name":"Ylojarvi",
     "wof:parent_id":1159321533,
     "wof:placetype":"localadmin",

--- a/data/907/199/277/907199277.geojson
+++ b/data/907/199/277/907199277.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_239",
         "eurostat:nuts_2021_id":"239",
+        "figov:code":"239",
+        "figov:id":"au782950",
         "gn:id":653389,
         "gp:id":12590733,
         "qs_pg:id":81467
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907199277,
-    "wof:lastmodified":1684352553,
+    "wof:lastmodified":1695877801,
     "wof:name":"Keitele",
     "wof:parent_id":1159321601,
     "wof:placetype":"localadmin",

--- a/data/907/199/279/907199279.geojson
+++ b/data/907/199/279/907199279.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_418",
         "eurostat:nuts_2021_id":"418",
+        "figov:code":"418",
+        "figov:id":"au784491",
         "gn:id":648369,
         "gp:id":12590670,
         "qs_pg:id":1062306
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199279,
-    "wof:lastmodified":1684352554,
+    "wof:lastmodified":1695877802,
     "wof:name":"Lempaala",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/199/281/907199281.geojson
+++ b/data/907/199/281/907199281.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_604",
         "eurostat:nuts_2021_id":"604",
+        "figov:code":"604",
+        "figov:id":"au784497",
         "gn:id":641491,
         "gp:id":12590681,
         "qs_pg:id":349799
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199281,
-    "wof:lastmodified":1684352554,
+    "wof:lastmodified":1695877802,
     "wof:name":"Pirkkala",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/199/283/907199283.geojson
+++ b/data/907/199/283/907199283.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_052",
         "eurostat:nuts_2021_id":"052",
+        "figov:code":"052",
+        "figov:id":"au788308",
         "gn:id":660067,
         "gp:id":12591031,
         "qs_pg:id":1030125
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199283,
-    "wof:lastmodified":1684352554,
+    "wof:lastmodified":1695877802,
     "wof:name":"Evijarvi",
     "wof:parent_id":1159321567,
     "wof:placetype":"localadmin",

--- a/data/907/199/285/907199285.geojson
+++ b/data/907/199/285/907199285.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,10 +123,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_743",
         "eurostat:nuts_2021_id":"743",
+        "figov:code":"743",
+        "figov:id":"au790844",
         "gn:id":637220,
         "gp:id":12591070,
         "qs_pg:id":1062292
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":907199285,
-    "wof:lastmodified":1684352554,
+    "wof:lastmodified":1695877802,
     "wof:name":"Seinajoki",
     "wof:parent_id":1159321561,
     "wof:placetype":"localadmin",

--- a/data/907/199/287/907199287.geojson
+++ b/data/907/199/287/907199287.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,10 +123,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_595",
         "eurostat:nuts_2021_id":"595",
+        "figov:code":"595",
+        "figov:id":"au797437",
         "gn:id":641863,
         "gp:id":12590740,
         "qs_pg:id":81367
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":907199287,
-    "wof:lastmodified":1684352554,
+    "wof:lastmodified":1695877803,
     "wof:name":"Pielavesi",
     "wof:parent_id":1159321601,
     "wof:placetype":"localadmin",

--- a/data/907/199/291/907199291.geojson
+++ b/data/907/199/291/907199291.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_300",
         "eurostat:nuts_2021_id":"300",
+        "figov:code":"300",
+        "figov:id":"au798109",
         "gn:id":650166,
         "gp:id":12591051,
         "qs_pg:id":953667
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907199291,
-    "wof:lastmodified":1684352555,
+    "wof:lastmodified":1695877805,
     "wof:name":"Kuortane",
     "wof:parent_id":1159321555,
     "wof:placetype":"localadmin",

--- a/data/907/199/293/907199293.geojson
+++ b/data/907/199/293/907199293.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,9 +129,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_924",
         "eurostat:nuts_2021_id":"924",
+        "figov:code":"924",
+        "figov:id":"au798553",
         "gn:id":631827,
         "qs_pg:id":81281
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -146,7 +155,7 @@
         }
     ],
     "wof:id":907199293,
-    "wof:lastmodified":1684352555,
+    "wof:lastmodified":1695877805,
     "wof:name":"Veteli",
     "wof:parent_id":1159321595,
     "wof:placetype":"localadmin",

--- a/data/907/199/295/907199295.geojson
+++ b/data/907/199/295/907199295.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -129,10 +132,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_702",
         "eurostat:nuts_2021_id":"702",
+        "figov:code":"702",
+        "figov:id":"au803344",
         "gn:id":638693,
         "gp:id":12590684,
         "qs_pg:id":81341
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":907199295,
-    "wof:lastmodified":1684352555,
+    "wof:lastmodified":1695877805,
     "wof:name":"Ruovesi",
     "wof:parent_id":1159321485,
     "wof:placetype":"localadmin",

--- a/data/907/199/297/907199297.geojson
+++ b/data/907/199/297/907199297.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -156,10 +159,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_143",
         "eurostat:nuts_2021_id":"143",
+        "figov:code":"143",
+        "figov:id":"au805344",
         "gn:id":656790,
         "gp:id":12590655,
         "qs_pg:id":1030110
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -177,7 +186,7 @@
         }
     ],
     "wof:id":907199297,
-    "wof:lastmodified":1684352555,
+    "wof:lastmodified":1695877806,
     "wof:name":"Ikaalinen",
     "wof:parent_id":1159321533,
     "wof:placetype":"localadmin",

--- a/data/907/199/299/907199299.geojson
+++ b/data/907/199/299/907199299.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_214",
         "eurostat:nuts_2021_id":"214",
+        "figov:code":"214",
+        "figov:id":"au807242",
         "gn:id":654377,
         "gp:id":12590917,
         "qs_pg:id":81486
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199299,
-    "wof:lastmodified":1684352556,
+    "wof:lastmodified":1695877806,
     "wof:name":"Kankaanpaa",
     "wof:parent_id":1159321519,
     "wof:placetype":"localadmin",

--- a/data/907/199/301/907199301.geojson
+++ b/data/907/199/301/907199301.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_074",
         "eurostat:nuts_2021_id":"074",
+        "figov:code":"074",
+        "figov:id":"au815631",
         "gn:id":659231,
         "gp:id":12591032,
         "qs_pg:id":953669
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907199301,
-    "wof:lastmodified":1684352556,
+    "wof:lastmodified":1695877806,
     "wof:name":"Halsua",
     "wof:parent_id":1159321595,
     "wof:placetype":"localadmin",

--- a/data/907/199/305/907199305.geojson
+++ b/data/907/199/305/907199305.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -121,9 +124,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_236",
         "eurostat:nuts_2021_id":"236",
+        "figov:code":"236",
+        "figov:id":"au815657",
         "gn:id":653484,
         "qs_pg:id":81470
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":907199305,
-    "wof:lastmodified":1684352556,
+    "wof:lastmodified":1695877807,
     "wof:name":"Kaustinen",
     "wof:parent_id":1159321595,
     "wof:placetype":"localadmin",

--- a/data/907/199/309/907199309.geojson
+++ b/data/907/199/309/907199309.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,10 +123,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_849",
         "eurostat:nuts_2021_id":"849",
+        "figov:code":"849",
+        "figov:id":"au820538",
         "gn:id":634325,
         "gp:id":12591073,
         "qs_pg:id":81305
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":907199309,
-    "wof:lastmodified":1684352556,
+    "wof:lastmodified":1695877807,
     "wof:name":"Toholampi",
     "wof:parent_id":1159321595,
     "wof:placetype":"localadmin",

--- a/data/907/199/313/907199313.geojson
+++ b/data/907/199/313/907199313.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_204",
         "eurostat:nuts_2021_id":"204",
+        "figov:code":"204",
+        "figov:id":"au823439",
         "gn:id":655070,
         "gp:id":12590731,
         "qs_pg:id":81488
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907199313,
-    "wof:lastmodified":1684352556,
+    "wof:lastmodified":1695877807,
     "wof:name":"Kaavi",
     "wof:parent_id":1159321579,
     "wof:placetype":"localadmin",

--- a/data/907/199/319/907199319.geojson
+++ b/data/907/199/319/907199319.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -141,10 +144,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_765",
         "eurostat:nuts_2021_id":"765",
+        "figov:code":"765",
+        "figov:id":"au826438",
         "gn:id":636173,
         "gp:id":12590871,
         "qs_pg:id":988711
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -162,7 +171,7 @@
         }
     ],
     "wof:id":907199319,
-    "wof:lastmodified":1684352556,
+    "wof:lastmodified":1695877807,
     "wof:name":"Sotkamo",
     "wof:parent_id":1159321487,
     "wof:placetype":"localadmin",

--- a/data/907/199/323/907199323.geojson
+++ b/data/907/199/323/907199323.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -120,10 +123,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_687",
         "eurostat:nuts_2021_id":"687",
+        "figov:code":"687",
+        "figov:id":"au828094",
         "gn:id":639701,
         "gp:id":12590742,
         "qs_pg:id":81348
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -141,7 +150,7 @@
         }
     ],
     "wof:id":907199323,
-    "wof:lastmodified":1684352557,
+    "wof:lastmodified":1695877808,
     "wof:name":"Rautavaara",
     "wof:parent_id":1159321579,
     "wof:placetype":"localadmin",

--- a/data/907/199/331/907199331.geojson
+++ b/data/907/199/331/907199331.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_762",
         "eurostat:nuts_2021_id":"762",
+        "figov:code":"762",
+        "figov:id":"au833283",
         "gn:id":636305,
         "gp:id":12590744,
         "qs_pg:id":550545
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199331,
-    "wof:lastmodified":1684352557,
+    "wof:lastmodified":1695877809,
     "wof:name":"Sonkajarvi",
     "wof:parent_id":1159321601,
     "wof:placetype":"localadmin",

--- a/data/907/199/339/907199339.geojson
+++ b/data/907/199/339/907199339.geojson
@@ -11,7 +11,7 @@
     "figov:national_code":"174",
     "figov:swe_type":"Kommun",
     "geom:area":0.104139,
-    "geom:area_square_m":582673999.30591,
+    "geom:area_square_m":582673999.305647,
     "geom:bbox":"27.9702834344,62.9410123143,28.7623868144,63.2786786507",
     "geom:latitude":63.096159,
     "geom:longitude":28.352068,
@@ -21,6 +21,9 @@
     ],
     "label:fin_x_preferred_placetype":[
         "kunta"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:swe_x_preferred_placetype":[
         "kommun"
@@ -128,15 +131,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "figov:code":"174",
+        "figov:id":"au834594",
         "gn:id":655533,
         "gp:id":12590730,
         "qs_pg:id":953614
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
     ],
-    "wof:geomhash":"a2f9fbc51163d656d8aa9696fdc1b6c0",
+    "wof:geomhash":"d69f5fbb44508947b4e9211843a4f567",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":907199339,
-    "wof:lastmodified":1582312088,
+    "wof:lastmodified":1695877713,
     "wof:name":"Juankoski",
     "wof:parent_id":1159321597,
     "wof:placetype":"localadmin",

--- a/data/907/199/347/907199347.geojson
+++ b/data/907/199/347/907199347.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_746",
         "eurostat:nuts_2021_id":"746",
+        "figov:code":"746",
+        "figov:id":"au837384",
         "gn:id":637035,
         "gp:id":12590869,
         "qs_pg:id":202549
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907199347,
-    "wof:lastmodified":1684352558,
+    "wof:lastmodified":1695877810,
     "wof:name":"Sievi",
     "wof:parent_id":1159321569,
     "wof:placetype":"localadmin",

--- a/data/907/199/351/907199351.geojson
+++ b/data/907/199/351/907199351.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -165,10 +168,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_140",
         "eurostat:nuts_2021_id":"140",
+        "figov:code":"140",
+        "figov:id":"au841046",
         "gn:id":656821,
         "gp:id":12590729,
         "qs_pg:id":1151732
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -186,7 +195,7 @@
         }
     ],
     "wof:id":907199351,
-    "wof:lastmodified":1684352558,
+    "wof:lastmodified":1695877811,
     "wof:name":"Iisalmi",
     "wof:parent_id":1159321601,
     "wof:placetype":"localadmin",

--- a/data/907/199/359/907199359.geojson
+++ b/data/907/199/359/907199359.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_925",
         "eurostat:nuts_2021_id":"925",
+        "figov:code":"925",
+        "figov:id":"au842362",
         "gn:id":631780,
         "qs_pg:id":81280
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907199359,
-    "wof:lastmodified":1684352559,
+    "wof:lastmodified":1695877813,
     "wof:name":"Vierema",
     "wof:parent_id":1159321601,
     "wof:placetype":"localadmin",

--- a/data/907/199/369/907199369.geojson
+++ b/data/907/199/369/907199369.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_844",
         "eurostat:nuts_2021_id":"844",
+        "figov:code":"844",
+        "figov:id":"au843127",
         "gn:id":634612,
         "gp:id":12590746,
         "qs_pg:id":81308
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907199369,
-    "wof:lastmodified":1684352560,
+    "wof:lastmodified":1695877814,
     "wof:name":"Tervo",
     "wof:parent_id":1159321623,
     "wof:placetype":"localadmin",

--- a/data/907/199/373/907199373.geojson
+++ b/data/907/199/373/907199373.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_402",
         "eurostat:nuts_2021_id":"402",
+        "figov:code":"402",
+        "figov:id":"au844193",
         "gn:id":648957,
         "gp:id":12590736,
         "qs_pg:id":1030092
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907199373,
-    "wof:lastmodified":1684352561,
+    "wof:lastmodified":1695877815,
     "wof:name":"Lapinlahti",
     "wof:parent_id":1159321601,
     "wof:placetype":"localadmin",

--- a/data/907/199/385/907199385.geojson
+++ b/data/907/199/385/907199385.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,10 +129,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_177",
         "eurostat:nuts_2021_id":"177",
+        "figov:code":"177",
+        "figov:id":"au845537",
         "gn:id":655307,
         "gp:id":12590658,
         "qs_pg:id":189496
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907199385,
-    "wof:lastmodified":1684352562,
+    "wof:lastmodified":1695877817,
     "wof:name":"Juupajoki",
     "wof:parent_id":1159321485,
     "wof:placetype":"localadmin",

--- a/data/907/199/389/907199389.geojson
+++ b/data/907/199/389/907199389.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_176",
         "eurostat:nuts_2021_id":"176",
+        "figov:code":"176",
+        "figov:id":"au847500",
         "gn:id":655312,
         "gp:id":12590886,
         "qs_pg:id":1207070
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907199389,
-    "wof:lastmodified":1684352562,
+    "wof:lastmodified":1695877817,
     "wof:name":"Juuka",
     "wof:parent_id":1159321551,
     "wof:placetype":"localadmin",

--- a/data/907/199/393/907199393.geojson
+++ b/data/907/199/393/907199393.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_562",
         "eurostat:nuts_2021_id":"562",
+        "figov:code":"562",
+        "figov:id":"au847506",
         "gn:id":643631,
         "gp:id":12590677,
         "qs_pg:id":369879
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907199393,
-    "wof:lastmodified":1684352562,
+    "wof:lastmodified":1695877818,
     "wof:name":"Orivesi",
     "wof:parent_id":1159321521,
     "wof:placetype":"localadmin",

--- a/data/907/199/399/907199399.geojson
+++ b/data/907/199/399/907199399.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -93,10 +96,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_607",
         "eurostat:nuts_2021_id":"607",
+        "figov:code":"607",
+        "figov:id":"au848910",
         "gn:id":641055,
         "gp:id":12590895,
         "qs_pg:id":245367
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":907199399,
-    "wof:lastmodified":1684352562,
+    "wof:lastmodified":1695877819,
     "wof:name":"Polvijarvi",
     "wof:parent_id":1159321551,
     "wof:placetype":"localadmin",

--- a/data/907/199/405/907199405.geojson
+++ b/data/907/199/405/907199405.geojson
@@ -11,7 +11,7 @@
     "figov:national_code":"911",
     "figov:swe_type":"Kommun",
     "geom:area":0.152216,
-    "geom:area_square_m":832837285.313417,
+    "geom:area_square_m":832837285.313477,
     "geom:bbox":"28.3597234212,63.5580892041,29.204865278,63.8824146681",
     "geom:latitude":63.737356,
     "geom:longitude":28.757498,
@@ -21,6 +21,9 @@
     ],
     "label:fin_x_preferred_placetype":[
         "kunta"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:swe_x_preferred_placetype":[
         "kommun"
@@ -119,15 +122,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "figov:code":"911",
+        "figov:id":"au851608",
         "gn:id":632553,
         "gp:id":12590900,
         "qs_pg:id":244397
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
     ],
-    "wof:geomhash":"5c7c7013904c7861c88c097f74c9d3fb",
+    "wof:geomhash":"cd9494b2871f89e61ca1a2e4ef496256",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -140,7 +149,7 @@
         }
     ],
     "wof:id":907199405,
-    "wof:lastmodified":1582312133,
+    "wof:lastmodified":1695877718,
     "wof:name":"Valtimo",
     "wof:parent_id":1159321575,
     "wof:placetype":"localadmin",

--- a/data/907/199/409/907199409.geojson
+++ b/data/907/199/409/907199409.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_541",
         "eurostat:nuts_2021_id":"541",
+        "figov:code":"541",
+        "figov:id":"au852269",
         "gn:id":644187,
         "gp:id":12590893,
         "qs_pg:id":248322
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907199409,
-    "wof:lastmodified":1684352563,
+    "wof:lastmodified":1695877819,
     "wof:name":"Nurmes",
     "wof:parent_id":1159321575,
     "wof:placetype":"localadmin",

--- a/data/907/199/417/907199417.geojson
+++ b/data/907/199/417/907199417.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_848",
         "eurostat:nuts_2021_id":"848",
+        "figov:code":"848",
+        "figov:id":"au855215",
         "gn:id":634333,
         "gp:id":12590898,
         "qs_pg:id":1062296
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199417,
-    "wof:lastmodified":1684352563,
+    "wof:lastmodified":1695877820,
     "wof:name":"Tohmajarvi",
     "wof:parent_id":1159321517,
     "wof:placetype":"localadmin",

--- a/data/907/199/425/907199425.geojson
+++ b/data/907/199/425/907199425.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_749",
         "eurostat:nuts_2021_id":"749",
+        "figov:code":"749",
+        "figov:id":"au857823",
         "gn:id":636948,
         "gp:id":12590743,
         "qs_pg:id":1029982
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199425,
-    "wof:lastmodified":1684352563,
+    "wof:lastmodified":1695877821,
     "wof:name":"Siilinjarvi",
     "wof:parent_id":1159321597,
     "wof:placetype":"localadmin",

--- a/data/907/199/429/907199429.geojson
+++ b/data/907/199/429/907199429.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -141,10 +144,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_009",
         "eurostat:nuts_2021_id":"009",
+        "figov:code":"009",
+        "figov:id":"au863061",
         "gn:id":661364,
         "gp:id":12590831,
         "qs_pg:id":244413
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -162,7 +171,7 @@
         }
     ],
     "wof:id":907199429,
-    "wof:lastmodified":1684352564,
+    "wof:lastmodified":1695877822,
     "wof:name":"Alavieska",
     "wof:parent_id":1159321569,
     "wof:placetype":"localadmin",

--- a/data/907/199/435/907199435.geojson
+++ b/data/907/199/435/907199435.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -150,9 +153,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_072",
         "eurostat:nuts_2021_id":"072",
+        "figov:code":"072",
+        "figov:id":"au869948",
         "gn:id":659433,
         "qs_pg:id":1030139
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -170,7 +179,7 @@
         }
     ],
     "wof:id":907199435,
-    "wof:lastmodified":1684352564,
+    "wof:lastmodified":1695877822,
     "wof:name":"Hailuoto",
     "wof:parent_id":1159321529,
     "wof:placetype":"localadmin",

--- a/data/907/199/437/907199437.geojson
+++ b/data/907/199/437/907199437.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -165,10 +168,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_977",
         "eurostat:nuts_2021_id":"977",
+        "figov:code":"977",
+        "figov:id":"au873419",
         "gn:id":630768,
         "gp:id":12590882,
         "qs_pg:id":474375
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -186,7 +195,7 @@
         }
     ],
     "wof:id":907199437,
-    "wof:lastmodified":1684352564,
+    "wof:lastmodified":1695877822,
     "wof:name":"Ylivieska",
     "wof:parent_id":1159321569,
     "wof:placetype":"localadmin",

--- a/data/907/199/441/907199441.geojson
+++ b/data/907/199/441/907199441.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -174,10 +177,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_061",
         "eurostat:nuts_2021_id":"061",
+        "figov:code":"061",
+        "figov:id":"au873769",
         "gn:id":659936,
         "gp:id":12590646,
         "qs_pg:id":1030124
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -195,7 +204,7 @@
         }
     ],
     "wof:id":907199441,
-    "wof:lastmodified":1684352564,
+    "wof:lastmodified":1695877822,
     "wof:name":"Forssa",
     "wof:parent_id":1159321511,
     "wof:placetype":"localadmin",

--- a/data/907/199/445/907199445.geojson
+++ b/data/907/199/445/907199445.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -165,10 +168,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_276",
         "eurostat:nuts_2021_id":"276",
+        "figov:code":"276",
+        "figov:id":"au876515",
         "gn:id":651660,
         "gp:id":12590890,
         "qs_pg:id":369917
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -186,7 +195,7 @@
         }
     ],
     "wof:id":907199445,
-    "wof:lastmodified":1684352564,
+    "wof:lastmodified":1695877822,
     "wof:name":"Kontiolahti",
     "wof:parent_id":1159321551,
     "wof:placetype":"localadmin",

--- a/data/907/199/449/907199449.geojson
+++ b/data/907/199/449/907199449.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -162,10 +165,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_678",
         "eurostat:nuts_2021_id":"678",
+        "figov:code":"678",
+        "figov:id":"au879928",
         "gn:id":640277,
         "gp:id":12590864,
         "qs_pg:id":1151713
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -183,7 +192,7 @@
         }
     ],
     "wof:id":907199449,
-    "wof:lastmodified":1684352564,
+    "wof:lastmodified":1695877823,
     "wof:name":"Raahe",
     "wof:parent_id":1159321631,
     "wof:placetype":"localadmin",

--- a/data/907/199/455/907199455.geojson
+++ b/data/907/199/455/907199455.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -207,10 +210,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_205",
         "eurostat:nuts_2021_id":"205",
+        "figov:code":"205",
+        "figov:id":"au883898",
         "gn:id":654901,
         "gp:id":12590838,
         "qs_pg:id":1151726
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -228,7 +237,7 @@
         }
     ],
     "wof:id":907199455,
-    "wof:lastmodified":1684352565,
+    "wof:lastmodified":1695877823,
     "wof:name":"Kajaani",
     "wof:parent_id":1159321487,
     "wof:placetype":"localadmin",

--- a/data/907/199/459/907199459.geojson
+++ b/data/907/199/459/907199459.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -315,10 +318,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_564",
         "eurostat:nuts_2021_id":"564",
+        "figov:code":"564",
+        "figov:id":"au887114",
         "gn:id":643493,
         "gp:id":56071673,
         "qs_pg:id":33489
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:coterminous":[
         101748443
     ],
@@ -339,7 +348,7 @@
         }
     ],
     "wof:id":907199459,
-    "wof:lastmodified":1684352565,
+    "wof:lastmodified":1695877823,
     "wof:name":"Oulu",
     "wof:parent_id":1159321529,
     "wof:placetype":"localadmin",

--- a/data/907/199/465/907199465.geojson
+++ b/data/907/199/465/907199465.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_317",
         "eurostat:nuts_2021_id":"317",
+        "figov:code":"317",
+        "figov:id":"au889030",
         "gn:id":653883,
         "gp:id":12590840,
         "qs_pg:id":81477
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199465,
-    "wof:lastmodified":1684352565,
+    "wof:lastmodified":1695877824,
     "wof:name":"Karsamaki",
     "wof:parent_id":1159321591,
     "wof:placetype":"localadmin",

--- a/data/907/199/471/907199471.geojson
+++ b/data/907/199/471/907199471.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -153,10 +156,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_071",
         "eurostat:nuts_2021_id":"071",
+        "figov:code":"071",
+        "figov:id":"au892756",
         "gn:id":659557,
         "gp:id":12590833,
         "qs_pg:id":81523
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -174,7 +183,7 @@
         }
     ],
     "wof:id":907199471,
-    "wof:lastmodified":1684352565,
+    "wof:lastmodified":1695877824,
     "wof:name":"Haapavesi",
     "wof:parent_id":1159321571,
     "wof:placetype":"localadmin",

--- a/data/907/199/475/907199475.geojson
+++ b/data/907/199/475/907199475.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_578",
         "eurostat:nuts_2021_id":"578",
+        "figov:code":"578",
+        "figov:id":"au901895",
         "gn:id":642750,
         "gp:id":12590855,
         "qs_pg:id":275161
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907199475,
-    "wof:lastmodified":1684352565,
+    "wof:lastmodified":1695877825,
     "wof:name":"Paltamo",
     "wof:parent_id":1159321487,
     "wof:placetype":"localadmin",

--- a/data/907/199/477/907199477.geojson
+++ b/data/907/199/477/907199477.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -141,10 +144,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_494",
         "eurostat:nuts_2021_id":"494",
+        "figov:code":"494",
+        "figov:id":"au908830",
         "gn:id":645767,
         "gp:id":12590850,
         "qs_pg:id":203716
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -162,7 +171,7 @@
         }
     ],
     "wof:id":907199477,
-    "wof:lastmodified":1684352566,
+    "wof:lastmodified":1695877825,
     "wof:name":"Muhos",
     "wof:parent_id":1159321529,
     "wof:placetype":"localadmin",

--- a/data/907/199/479/907199479.geojson
+++ b/data/907/199/479/907199479.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -158,6 +161,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_244",
         "eurostat:nuts_2021_id":"244",
+        "figov:code":"244",
+        "figov:id":"au914440",
         "gn:id":653252,
         "gp:id":12590841,
         "qs_pg:id":337776
@@ -166,6 +171,10 @@
         "gn:id":653253,
         "qs_pg:id":1030105
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -183,7 +192,7 @@
         }
     ],
     "wof:id":907199479,
-    "wof:lastmodified":1684352566,
+    "wof:lastmodified":1695877825,
     "wof:name":"Kempele",
     "wof:parent_id":1159321529,
     "wof:placetype":"localadmin",

--- a/data/907/199/481/907199481.geojson
+++ b/data/907/199/481/907199481.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -141,10 +144,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_263",
         "eurostat:nuts_2021_id":"263",
+        "figov:code":"263",
+        "figov:id":"au914851",
         "gn:id":652561,
         "gp:id":12590734,
         "qs_pg:id":81455
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -162,7 +171,7 @@
         }
     ],
     "wof:id":907199481,
-    "wof:lastmodified":1684352566,
+    "wof:lastmodified":1695877826,
     "wof:name":"Kiuruvesi",
     "wof:parent_id":1159321601,
     "wof:placetype":"localadmin",

--- a/data/907/199/485/907199485.geojson
+++ b/data/907/199/485/907199485.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -102,9 +105,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_751",
         "eurostat:nuts_2021_id":"751",
+        "figov:code":"751",
+        "figov:id":"au928417",
         "gn:id":636804,
         "qs_pg:id":81324
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -122,7 +131,7 @@
         }
     ],
     "wof:id":907199485,
-    "wof:lastmodified":1684352567,
+    "wof:lastmodified":1695877827,
     "wof:name":"Simo",
     "wof:parent_id":1159321559,
     "wof:placetype":"localadmin",

--- a/data/907/199/489/907199489.geojson
+++ b/data/907/199/489/907199489.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_483",
         "eurostat:nuts_2021_id":"483",
+        "figov:code":"483",
+        "figov:id":"au933486",
         "gn:id":646198,
         "gp:id":12590849,
         "qs_pg:id":81407
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199489,
-    "wof:lastmodified":1684352567,
+    "wof:lastmodified":1695877827,
     "wof:name":"Merijarvi",
     "wof:parent_id":1159321569,
     "wof:placetype":"localadmin",

--- a/data/907/199/491/907199491.geojson
+++ b/data/907/199/491/907199491.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -78,9 +81,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_630",
         "eurostat:nuts_2021_id":"630",
+        "figov:code":"630",
+        "figov:id":"au935695",
         "gn:id":640410,
         "qs_pg:id":81353
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":907199491,
-    "wof:lastmodified":1684352567,
+    "wof:lastmodified":1695877828,
     "wof:name":"Pyhanta",
     "wof:parent_id":1159321571,
     "wof:placetype":"localadmin",

--- a/data/907/199/493/907199493.geojson
+++ b/data/907/199/493/907199493.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_683",
         "eurostat:nuts_2021_id":"683",
+        "figov:code":"683",
+        "figov:id":"au940636",
         "gn:id":639888,
         "gp:id":12590791,
         "qs_pg:id":1008267
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907199493,
-    "wof:lastmodified":1684352567,
+    "wof:lastmodified":1695877828,
     "wof:name":"Ranua",
     "wof:parent_id":1159321523,
     "wof:placetype":"localadmin",

--- a/data/907/199/499/907199499.geojson
+++ b/data/907/199/499/907199499.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -111,10 +114,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_615",
         "eurostat:nuts_2021_id":"615",
+        "figov:code":"615",
+        "figov:id":"au943705",
         "gn:id":640803,
         "gp:id":12590858,
         "qs_pg:id":953654
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -132,7 +141,7 @@
         }
     ],
     "wof:id":907199499,
-    "wof:lastmodified":1684352567,
+    "wof:lastmodified":1695877828,
     "wof:name":"Pudasjarvi",
     "wof:parent_id":1159321497,
     "wof:placetype":"localadmin",

--- a/data/907/199/501/907199501.geojson
+++ b/data/907/199/501/907199501.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -162,9 +165,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_777",
         "eurostat:nuts_2021_id":"777",
+        "figov:code":"777",
+        "figov:id":"au945517",
         "gn:id":635697,
         "qs_pg:id":274920
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -182,7 +191,7 @@
         }
     ],
     "wof:id":907199501,
-    "wof:lastmodified":1684352568,
+    "wof:lastmodified":1695877829,
     "wof:name":"Suomussalmi",
     "wof:parent_id":1159321549,
     "wof:placetype":"localadmin",

--- a/data/907/199/503/907199503.geojson
+++ b/data/907/199/503/907199503.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_832",
         "eurostat:nuts_2021_id":"832",
+        "figov:code":"832",
+        "figov:id":"au946368",
         "gn:id":635142,
         "gp:id":12590873,
         "qs_pg:id":81314
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907199503,
-    "wof:lastmodified":1684352568,
+    "wof:lastmodified":1695877829,
     "wof:name":"Taivalkoski",
     "wof:parent_id":1159321489,
     "wof:placetype":"localadmin",

--- a/data/907/199/507/907199507.geojson
+++ b/data/907/199/507/907199507.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -156,10 +159,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_290",
         "eurostat:nuts_2021_id":"290",
+        "figov:code":"290",
+        "figov:id":"au946876",
         "gn:id":650705,
         "gp:id":12590844,
         "qs_pg:id":582219
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -177,7 +186,7 @@
         }
     ],
     "wof:id":907199507,
-    "wof:lastmodified":1684352568,
+    "wof:lastmodified":1695877829,
     "wof:name":"Kuhmo",
     "wof:parent_id":1159321549,
     "wof:placetype":"localadmin",

--- a/data/907/199/509/907199509.geojson
+++ b/data/907/199/509/907199509.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -81,10 +84,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_889",
         "eurostat:nuts_2021_id":"889",
+        "figov:code":"889",
+        "figov:id":"au953140",
         "gn:id":633295,
         "gp:id":12590876,
         "qs_pg:id":1207060
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":907199509,
-    "wof:lastmodified":1684352568,
+    "wof:lastmodified":1695877829,
     "wof:name":"Utajarvi",
     "wof:parent_id":1159321497,
     "wof:placetype":"localadmin",

--- a/data/907/199/513/907199513.geojson
+++ b/data/907/199/513/907199513.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_620",
         "eurostat:nuts_2021_id":"620",
+        "figov:code":"620",
+        "figov:id":"au955479",
         "gn:id":640660,
         "gp:id":12590860,
         "qs_pg:id":81358
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907199513,
-    "wof:lastmodified":1684352568,
+    "wof:lastmodified":1695877830,
     "wof:name":"Puolanka",
     "wof:parent_id":1159321549,
     "wof:placetype":"localadmin",

--- a/data/907/199/517/907199517.geojson
+++ b/data/907/199/517/907199517.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -151,10 +154,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_563",
         "eurostat:nuts_2021_id":"563",
+        "figov:code":"563",
+        "figov:id":"au955805",
         "gn:id":643498,
         "gp:id":12590852,
         "qs_pg:id":81383
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -172,7 +181,7 @@
         }
     ],
     "wof:id":907199517,
-    "wof:lastmodified":1684352569,
+    "wof:lastmodified":1695877831,
     "wof:name":"Oulainen",
     "wof:parent_id":1159321569,
     "wof:placetype":"localadmin",

--- a/data/907/199/519/907199519.geojson
+++ b/data/907/199/519/907199519.geojson
@@ -37,6 +37,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -209,6 +212,8 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_305",
         "eurostat:nuts_2021_id":"305",
+        "figov:code":"305",
+        "figov:id":"au958632",
         "gn:id":649924,
         "gp:id":12590846,
         "qs_pg:id":582218
@@ -217,6 +222,10 @@
         "gn:id":649925,
         "qs_pg:id":369913
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -234,7 +243,7 @@
         }
     ],
     "wof:id":907199519,
-    "wof:lastmodified":1684352569,
+    "wof:lastmodified":1695877831,
     "wof:name":"Kuusamo",
     "wof:parent_id":1159321489,
     "wof:placetype":"localadmin",

--- a/data/907/199/525/907199525.geojson
+++ b/data/907/199/525/907199525.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_146",
         "eurostat:nuts_2021_id":"146",
+        "figov:code":"146",
+        "figov:id":"au961732",
         "gn:id":656709,
         "gp:id":12590884,
         "qs_pg:id":225394
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907199525,
-    "wof:lastmodified":1684352569,
+    "wof:lastmodified":1695877831,
     "wof:name":"Ilomantsi",
     "wof:parent_id":1159321551,
     "wof:placetype":"localadmin",

--- a/data/907/199/527/907199527.geojson
+++ b/data/907/199/527/907199527.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_697",
         "eurostat:nuts_2021_id":"697",
+        "figov:code":"697",
+        "figov:id":"au963356",
         "gn:id":639247,
         "qs_pg:id":550550
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907199527,
-    "wof:lastmodified":1684352569,
+    "wof:lastmodified":1695877832,
     "wof:name":"Ristijarvi",
     "wof:parent_id":1159321487,
     "wof:placetype":"localadmin",

--- a/data/907/199/531/907199531.geojson
+++ b/data/907/199/531/907199531.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,9 +141,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_105",
         "eurostat:nuts_2021_id":"105",
+        "figov:code":"105",
+        "figov:id":"au963741",
         "gn:id":656951,
         "qs_pg:id":81501
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -158,7 +167,7 @@
         }
     ],
     "wof:id":907199531,
-    "wof:lastmodified":1684352570,
+    "wof:lastmodified":1695877832,
     "wof:name":"Hyrynsalmi",
     "wof:parent_id":1159321549,
     "wof:placetype":"localadmin",

--- a/data/907/199/533/907199533.geojson
+++ b/data/907/199/533/907199533.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_614",
         "eurostat:nuts_2021_id":"614",
+        "figov:code":"614",
+        "figov:id":"au964950",
         "gn:id":640893,
         "gp:id":12590790,
         "qs_pg:id":985627
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199533,
-    "wof:lastmodified":1684352570,
+    "wof:lastmodified":1695877832,
     "wof:name":"Posio",
     "wof:parent_id":1159321535,
     "wof:placetype":"localadmin",

--- a/data/907/199/537/907199537.geojson
+++ b/data/907/199/537/907199537.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,10 +138,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_436",
         "eurostat:nuts_2021_id":"436",
+        "figov:code":"436",
+        "figov:id":"au965549",
         "gn:id":647472,
         "gp:id":12590848,
         "qs_pg:id":369896
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -156,7 +165,7 @@
         }
     ],
     "wof:id":907199537,
-    "wof:lastmodified":1684352570,
+    "wof:lastmodified":1695877833,
     "wof:name":"Lumijoki",
     "wof:parent_id":1159321529,
     "wof:placetype":"localadmin",

--- a/data/907/199/539/907199539.geojson
+++ b/data/907/199/539/907199539.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -114,10 +117,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_320",
         "eurostat:nuts_2021_id":"320",
+        "figov:code":"320",
+        "figov:id":"au969421",
         "gn:id":653272,
         "gp:id":12590783,
         "qs_pg:id":1251866
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -135,7 +144,7 @@
         }
     ],
     "wof:id":907199539,
-    "wof:lastmodified":1684352570,
+    "wof:lastmodified":1695877833,
     "wof:name":"Kemijarvi",
     "wof:parent_id":1159321535,
     "wof:placetype":"localadmin",

--- a/data/907/199/545/907199545.geojson
+++ b/data/907/199/545/907199545.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,9 +141,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_845",
         "eurostat:nuts_2021_id":"845",
+        "figov:code":"845",
+        "figov:id":"au973607",
         "gn:id":634602,
         "qs_pg:id":244401
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -158,7 +167,7 @@
         }
     ],
     "wof:id":907199545,
-    "wof:lastmodified":1684352570,
+    "wof:lastmodified":1695877833,
     "wof:name":"Tervola",
     "wof:parent_id":1159321559,
     "wof:placetype":"localadmin",

--- a/data/907/199/549/907199549.geojson
+++ b/data/907/199/549/907199549.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,9 +147,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_976",
         "eurostat:nuts_2021_id":"976",
+        "figov:code":"976",
+        "figov:id":"au975927",
         "gn:id":630780,
         "qs_pg:id":550539
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -164,7 +173,7 @@
         }
     ],
     "wof:id":907199549,
-    "wof:lastmodified":1684352570,
+    "wof:lastmodified":1695877833,
     "wof:name":"Ylitornio",
     "wof:parent_id":1159321537,
     "wof:placetype":"localadmin",

--- a/data/907/199/553/907199553.geojson
+++ b/data/907/199/553/907199553.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -141,9 +144,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_854",
         "eurostat:nuts_2021_id":"854",
+        "figov:code":"854",
+        "figov:id":"au976563",
         "gn:id":642368,
         "qs_pg:id":369858
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -161,7 +170,7 @@
         }
     ],
     "wof:id":907199553,
-    "wof:lastmodified":1684352570,
+    "wof:lastmodified":1695877834,
     "wof:name":"Pello",
     "wof:parent_id":1159321537,
     "wof:placetype":"localadmin",

--- a/data/907/199/555/907199555.geojson
+++ b/data/907/199/555/907199555.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -159,10 +162,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_732",
         "eurostat:nuts_2021_id":"732",
+        "figov:code":"732",
+        "figov:id":"au977904",
         "gn:id":638075,
         "gp:id":12590794,
         "qs_pg:id":81336
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -180,7 +189,7 @@
         }
     ],
     "wof:id":907199555,
-    "wof:lastmodified":1684352571,
+    "wof:lastmodified":1695877834,
     "wof:name":"Salla",
     "wof:parent_id":1159321535,
     "wof:placetype":"localadmin",

--- a/data/907/199/557/907199557.geojson
+++ b/data/907/199/557/907199557.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -186,9 +189,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_851",
         "eurostat:nuts_2021_id":"851",
+        "figov:code":"851",
+        "figov:id":"au979804",
         "gn:id":634096,
         "qs_pg:id":369828
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -206,7 +215,7 @@
         }
     ],
     "wof:id":907199557,
-    "wof:lastmodified":1684352571,
+    "wof:lastmodified":1695877835,
     "wof:name":"Tornio",
     "wof:parent_id":1159321559,
     "wof:placetype":"localadmin",

--- a/data/907/199/561/907199561.geojson
+++ b/data/907/199/561/907199561.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_758",
         "eurostat:nuts_2021_id":"758",
+        "figov:code":"758",
+        "figov:id":"au981582",
         "gn:id":636465,
         "gp:id":12590797,
         "qs_pg:id":81320
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199561,
-    "wof:lastmodified":1684352571,
+    "wof:lastmodified":1695877836,
     "wof:name":"Sodankyla",
     "wof:parent_id":1159321531,
     "wof:placetype":"localadmin",

--- a/data/907/199/565/907199565.geojson
+++ b/data/907/199/565/907199565.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -90,10 +93,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_261",
         "eurostat:nuts_2021_id":"261",
+        "figov:code":"261",
+        "figov:id":"au982353",
         "gn:id":652594,
         "gp:id":12590785,
         "qs_pg:id":81456
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -111,7 +120,7 @@
         }
     ],
     "wof:id":907199565,
-    "wof:lastmodified":1684352572,
+    "wof:lastmodified":1695877836,
     "wof:name":"Kittila",
     "wof:parent_id":1159321583,
     "wof:placetype":"localadmin",

--- a/data/907/199/567/907199567.geojson
+++ b/data/907/199/567/907199567.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -156,10 +159,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_148",
         "eurostat:nuts_2021_id":"148",
+        "figov:code":"148",
+        "figov:id":"au982739",
         "gn:id":656659,
         "gp:id":12590781,
         "qs_pg:id":1030108
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -177,7 +186,7 @@
         }
     ],
     "wof:id":907199567,
-    "wof:lastmodified":1684352572,
+    "wof:lastmodified":1695877836,
     "wof:name":"Inari",
     "wof:parent_id":1159321531,
     "wof:placetype":"localadmin",

--- a/data/907/199/569/907199569.geojson
+++ b/data/907/199/569/907199569.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_241",
         "eurostat:nuts_2021_id":"241",
+        "figov:code":"241",
+        "figov:id":"au983630",
         "gn:id":653280,
         "gp:id":12590784,
         "qs_pg:id":260236
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199569,
-    "wof:lastmodified":1684352572,
+    "wof:lastmodified":1695877837,
     "wof:name":"Keminmaa",
     "wof:parent_id":1159321559,
     "wof:placetype":"localadmin",

--- a/data/907/199/571/907199571.geojson
+++ b/data/907/199/571/907199571.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_583",
         "eurostat:nuts_2021_id":"583",
+        "figov:code":"583",
+        "figov:id":"au984126",
         "gn:id":642377,
         "gp:id":12590788,
         "qs_pg:id":1317349
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199571,
-    "wof:lastmodified":1684352572,
+    "wof:lastmodified":1695877837,
     "wof:name":"Pelkosenniemi",
     "wof:parent_id":1159321535,
     "wof:placetype":"localadmin",

--- a/data/907/199/575/907199575.geojson
+++ b/data/907/199/575/907199575.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -159,10 +162,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_890",
         "eurostat:nuts_2021_id":"890",
+        "figov:code":"890",
+        "figov:id":"au985142",
         "gn:id":633268,
         "gp:id":12590800,
         "qs_pg:id":1207053
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -180,7 +189,7 @@
         }
     ],
     "wof:id":907199575,
-    "wof:lastmodified":1684352572,
+    "wof:lastmodified":1695877837,
     "wof:name":"Utsjoki",
     "wof:parent_id":1159321531,
     "wof:placetype":"localadmin",

--- a/data/907/199/579/907199579.geojson
+++ b/data/907/199/579/907199579.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_742",
         "eurostat:nuts_2021_id":"742",
+        "figov:code":"742",
+        "figov:id":"au985163",
         "gn:id":637285,
         "gp:id":12590795,
         "qs_pg:id":1157870
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199579,
-    "wof:lastmodified":1684352572,
+    "wof:lastmodified":1695877837,
     "wof:name":"Savukoski",
     "wof:parent_id":1159321535,
     "wof:placetype":"localadmin",

--- a/data/907/199/583/907199583.geojson
+++ b/data/907/199/583/907199583.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_273",
         "eurostat:nuts_2021_id":"273",
+        "figov:code":"273",
+        "figov:id":"au985784",
         "gn:id":651892,
         "gp:id":12590786,
         "qs_pg:id":81451
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199583,
-    "wof:lastmodified":1684352572,
+    "wof:lastmodified":1695877838,
     "wof:name":"Kolari",
     "wof:parent_id":1159321583,
     "wof:placetype":"localadmin",

--- a/data/907/199/587/907199587.geojson
+++ b/data/907/199/587/907199587.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -177,10 +180,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_498",
         "eurostat:nuts_2021_id":"498",
+        "figov:code":"498",
+        "figov:id":"au986232",
         "gn:id":645672,
         "gp:id":12590787,
         "qs_pg:id":1317350
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -198,7 +207,7 @@
         }
     ],
     "wof:id":907199587,
-    "wof:lastmodified":1684352573,
+    "wof:lastmodified":1695877838,
     "wof:name":"Muonio",
     "wof:parent_id":1159321583,
     "wof:placetype":"localadmin",

--- a/data/907/199/591/907199591.geojson
+++ b/data/907/199/591/907199591.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -276,10 +279,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_698",
         "eurostat:nuts_2021_id":"698",
+        "figov:code":"698",
+        "figov:id":"au988685",
         "gn:id":638937,
         "gp:id":12590793,
         "qs_pg:id":1026788
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -297,7 +306,7 @@
         }
     ],
     "wof:id":907199591,
-    "wof:lastmodified":1684352573,
+    "wof:lastmodified":1695877838,
     "wof:name":"Rovaniemi",
     "wof:parent_id":1159321523,
     "wof:placetype":"localadmin",

--- a/data/907/199/597/907199597.geojson
+++ b/data/907/199/597/907199597.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -213,10 +216,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_240",
         "eurostat:nuts_2021_id":"240",
+        "figov:code":"240",
+        "figov:id":"au988838",
         "gn:id":653282,
         "gp:id":12590782,
         "qs_pg:id":81466
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -234,7 +243,7 @@
         }
     ],
     "wof:id":907199597,
-    "wof:lastmodified":1684352573,
+    "wof:lastmodified":1695877838,
     "wof:name":"Kemi",
     "wof:parent_id":1159321559,
     "wof:placetype":"localadmin",

--- a/data/907/199/599/907199599.geojson
+++ b/data/907/199/599/907199599.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -84,10 +87,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_047",
         "eurostat:nuts_2021_id":"047",
+        "figov:code":"047",
+        "figov:id":"au989324",
         "gn:id":660230,
         "gp:id":12590780,
         "qs_pg:id":81526
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":907199599,
-    "wof:lastmodified":1684352573,
+    "wof:lastmodified":1695877838,
     "wof:name":"Enontekio",
     "wof:parent_id":1159321583,
     "wof:placetype":"localadmin",

--- a/data/907/199/603/907199603.geojson
+++ b/data/907/199/603/907199603.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -117,10 +120,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_694",
         "eurostat:nuts_2021_id":"694",
+        "figov:code":"694",
+        "figov:id":"au990317",
         "gn:id":639406,
         "gp:id":12590683,
         "qs_pg:id":904896
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -138,7 +147,7 @@
         }
     ],
     "wof:id":907199603,
-    "wof:lastmodified":1684352573,
+    "wof:lastmodified":1695877839,
     "wof:name":"Riihimaki",
     "wof:parent_id":1159321541,
     "wof:placetype":"localadmin",

--- a/data/907/199/605/907199605.geojson
+++ b/data/907/199/605/907199605.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -156,10 +159,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_422",
         "eurostat:nuts_2021_id":"422",
+        "figov:code":"422",
+        "figov:id":"au990510",
         "gn:id":648091,
         "gp:id":12590891,
         "qs_pg:id":81416
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -177,7 +186,7 @@
         }
     ],
     "wof:id":907199605,
-    "wof:lastmodified":1684352573,
+    "wof:lastmodified":1695877839,
     "wof:name":"Lieksa",
     "wof:parent_id":1159321575,
     "wof:placetype":"localadmin",

--- a/data/907/199/609/907199609.geojson
+++ b/data/907/199/609/907199609.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -258,10 +261,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_167",
         "eurostat:nuts_2021_id":"167",
+        "figov:code":"167",
+        "figov:id":"au990539",
         "gn:id":655823,
         "gp:id":12590885,
         "qs_pg:id":81489
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -279,7 +288,7 @@
         }
     ],
     "wof:id":907199609,
-    "wof:lastmodified":1684352574,
+    "wof:lastmodified":1695877839,
     "wof:name":"Joensuu",
     "wof:parent_id":1159321551,
     "wof:placetype":"localadmin",

--- a/data/907/199/615/907199615.geojson
+++ b/data/907/199/615/907199615.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,10 +75,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_859",
         "eurostat:nuts_2021_id":"859",
+        "figov:code":"859",
+        "figov:id":"au1007863",
         "gn:id":633541,
         "gp:id":12590875,
         "qs_pg:id":1212357
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -93,7 +102,7 @@
         }
     ],
     "wof:id":907199615,
-    "wof:lastmodified":1684352574,
+    "wof:lastmodified":1695877840,
     "wof:name":"Tyrnava",
     "wof:parent_id":1159321529,
     "wof:placetype":"localadmin",

--- a/data/907/199/617/907199617.geojson
+++ b/data/907/199/617/907199617.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,10 +150,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_208",
         "eurostat:nuts_2021_id":"208",
+        "figov:code":"208",
+        "figov:id":"au1009461",
         "gn:id":654837,
         "gp:id":12590839,
         "qs_pg:id":953657
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -168,7 +177,7 @@
         }
     ],
     "wof:id":907199617,
-    "wof:lastmodified":1684352574,
+    "wof:lastmodified":1695877841,
     "wof:name":"Kalajoki",
     "wof:parent_id":1159321569,
     "wof:placetype":"localadmin",

--- a/data/907/199/621/907199621.geojson
+++ b/data/907/199/621/907199621.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -132,10 +135,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_785",
         "eurostat:nuts_2021_id":"785",
+        "figov:code":"785",
+        "figov:id":"au1010117",
         "gn:id":633098,
         "gp:id":12590877,
         "qs_pg:id":81289
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -153,7 +162,7 @@
         }
     ],
     "wof:id":907199621,
-    "wof:lastmodified":1684352575,
+    "wof:lastmodified":1695877841,
     "wof:name":"Vaala",
     "wof:parent_id":1159321487,
     "wof:placetype":"localadmin",

--- a/data/907/199/625/907199625.geojson
+++ b/data/907/199/625/907199625.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_181",
         "eurostat:nuts_2021_id":"181",
+        "figov:code":"181",
+        "figov:id":"au1013317",
         "gn:id":656092,
         "gp:id":12590915,
         "qs_pg:id":81492
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199625,
-    "wof:lastmodified":1684352575,
+    "wof:lastmodified":1695877842,
     "wof:name":"Jamijarvi",
     "wof:parent_id":1159321519,
     "wof:placetype":"localadmin",

--- a/data/907/199/629/907199629.geojson
+++ b/data/907/199/629/907199629.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -144,10 +147,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_535",
         "eurostat:nuts_2021_id":"535",
+        "figov:code":"535",
+        "figov:id":"au1015880",
         "gn:id":644509,
         "gp:id":12590851,
         "qs_pg:id":37178
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -165,7 +174,7 @@
         }
     ],
     "wof:id":907199629,
-    "wof:lastmodified":1684352575,
+    "wof:lastmodified":1695877842,
     "wof:name":"Nivala",
     "wof:parent_id":1159321591,
     "wof:placetype":"localadmin",

--- a/data/907/199/633/907199633.geojson
+++ b/data/907/199/633/907199633.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -180,10 +183,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_235",
         "eurostat:nuts_2021_id":"235",
+        "figov:code":"235",
+        "figov:id":"au1017720",
         "gn:id":653560,
         "gp:id":12591000,
         "qs_pg:id":81471
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:coterminous":[
         101753897
     ],
@@ -204,7 +213,7 @@
         }
     ],
     "wof:id":907199633,
-    "wof:lastmodified":1684352575,
+    "wof:lastmodified":1695877842,
     "wof:name":"Kauniainen",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/199/635/907199635.geojson
+++ b/data/907/199/635/907199635.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -138,10 +141,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_425",
         "eurostat:nuts_2021_id":"425",
+        "figov:code":"425",
+        "figov:id":"au1017958",
         "gn:id":647931,
         "gp:id":12590847,
         "qs_pg:id":37176
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":907199635,
-    "wof:lastmodified":1684352575,
+    "wof:lastmodified":1695877842,
     "wof:name":"Liminka",
     "wof:parent_id":1159321529,
     "wof:placetype":"localadmin",

--- a/data/907/199/639/907199639.geojson
+++ b/data/907/199/639/907199639.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_069",
         "eurostat:nuts_2021_id":"069",
+        "figov:code":"069",
+        "figov:id":"au1018467",
         "gn:id":659701,
         "gp:id":12590832,
         "qs_pg:id":1030141
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199639,
-    "wof:lastmodified":1684352576,
+    "wof:lastmodified":1695877843,
     "wof:name":"Haapajarvi",
     "wof:parent_id":1159321591,
     "wof:placetype":"localadmin",

--- a/data/907/199/643/907199643.geojson
+++ b/data/907/199/643/907199643.geojson
@@ -11,7 +11,7 @@
     "figov:national_code":"442",
     "figov:swe_type":"Kommun",
     "geom:area":0.144713,
-    "geom:area_square_m":856361729.289063,
+    "geom:area_square_m":856361729.289128,
     "geom:bbox":"20.8296252016,61.2888399524,21.8046275055,61.5301785534",
     "geom:latitude":61.407536,
     "geom:longitude":21.263554,
@@ -21,6 +21,9 @@
     ],
     "label:fin_x_preferred_placetype":[
         "kunta"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:swe_x_preferred_placetype":[
         "kommun"
@@ -104,15 +107,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "figov:code":"442",
+        "figov:id":"au1023707",
         "gn:id":647261,
         "gp:id":12590940,
         "qs_pg:id":1026799
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
     ],
-    "wof:geomhash":"efded31cbfb2809516aed89624ea144d",
+    "wof:geomhash":"57727693c6dc8e37deec36dc38aea735",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -125,7 +134,7 @@
         }
     ],
     "wof:id":907199643,
-    "wof:lastmodified":1582312091,
+    "wof:lastmodified":1695877714,
     "wof:name":"Luvia",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/199/647/907199647.geojson
+++ b/data/907/199/647/907199647.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -131,8 +134,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_284",
-        "eurostat:nuts_2021_id":"284"
+        "eurostat:nuts_2021_id":"284",
+        "figov:code":"284",
+        "figov:id":"au1023739"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"1882877109b5532c1a2805ff9dc6656d",
     "wof:hierarchy":[
@@ -147,7 +156,7 @@
         }
     ],
     "wof:id":907199647,
-    "wof:lastmodified":1684352576,
+    "wof:lastmodified":1695877843,
     "wof:name":"Koski Tl",
     "wof:parent_id":1159321505,
     "wof:placetype":"localadmin",

--- a/data/907/199/651/907199651.geojson
+++ b/data/907/199/651/907199651.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -273,10 +276,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_092",
         "eurostat:nuts_2021_id":"092",
+        "figov:code":"092",
+        "figov:id":"au1032858",
         "gn:id":830153,
         "gp:id":12591025,
         "qs_pg:id":493007
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:coterminous":[
         101748419
     ],
@@ -297,7 +306,7 @@
         }
     ],
     "wof:id":907199651,
-    "wof:lastmodified":1684352576,
+    "wof:lastmodified":1695877843,
     "wof:name":"Vantaa",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/199/653/907199653.geojson
+++ b/data/907/199/653/907199653.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -243,10 +246,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_609",
         "eurostat:nuts_2021_id":"609",
+        "figov:code":"609",
+        "figov:id":"au1032889",
         "gn:id":641000,
         "gp:id":12590961,
         "qs_pg:id":550556
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -264,7 +273,7 @@
         }
     ],
     "wof:id":907199653,
-    "wof:lastmodified":1684352576,
+    "wof:lastmodified":1695877844,
     "wof:name":"Pori",
     "wof:parent_id":1159321565,
     "wof:placetype":"localadmin",

--- a/data/907/199/655/907199655.geojson
+++ b/data/907/199/655/907199655.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,9 +78,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_625",
         "eurostat:nuts_2021_id":"625",
+        "figov:code":"625",
+        "figov:id":"au1033490",
         "gn:id":640439,
         "qs_pg:id":81354
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":907199655,
-    "wof:lastmodified":1684352576,
+    "wof:lastmodified":1695877844,
     "wof:name":"Pyhajoki",
     "wof:parent_id":1159321631,
     "wof:placetype":"localadmin",

--- a/data/907/199/659/907199659.geojson
+++ b/data/907/199/659/907199659.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -66,8 +69,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_318",
-        "eurostat:nuts_2021_id":"318"
+        "eurostat:nuts_2021_id":"318",
+        "figov:code":"318",
+        "figov:id":"au1034844"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"5f11ebe2713f621ab28b735ac4310d3f",
     "wof:hierarchy":[
@@ -82,7 +91,7 @@
         }
     ],
     "wof:id":907199659,
-    "wof:lastmodified":1684352576,
+    "wof:lastmodified":1695877845,
     "wof:name":"Kokar",
     "wof:parent_id":1159321503,
     "wof:placetype":"localadmin",

--- a/data/907/199/661/907199661.geojson
+++ b/data/907/199/661/907199661.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,10 +75,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_545",
         "eurostat:nuts_2021_id":"545",
+        "figov:code":"545",
+        "figov:id":"au1035164",
         "gn:id":645082,
         "gp:id":12591063,
         "qs_pg:id":1030071
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -93,7 +102,7 @@
         }
     ],
     "wof:id":907199661,
-    "wof:lastmodified":1684352577,
+    "wof:lastmodified":1695877845,
     "wof:name":"Narpio",
     "wof:parent_id":1159321495,
     "wof:placetype":"localadmin",

--- a/data/907/199/665/907199665.geojson
+++ b/data/907/199/665/907199665.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -123,10 +126,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_846",
         "eurostat:nuts_2021_id":"846",
+        "figov:code":"846",
+        "figov:id":"au1035306",
         "gn:id":634562,
         "gp:id":12591072,
         "qs_pg:id":81307
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -144,7 +153,7 @@
         }
     ],
     "wof:id":907199665,
-    "wof:lastmodified":1684352577,
+    "wof:lastmodified":1695877845,
     "wof:name":"Teuva",
     "wof:parent_id":1159321543,
     "wof:placetype":"localadmin",

--- a/data/907/199/669/907199669.geojson
+++ b/data/907/199/669/907199669.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_288",
         "eurostat:nuts_2021_id":"288",
+        "figov:code":"288",
+        "figov:id":"au1035393",
         "gn:id":650755,
         "gp:id":12591050,
         "qs_pg:id":81443
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199669,
-    "wof:lastmodified":1684352577,
+    "wof:lastmodified":1695877845,
     "wof:name":"Kruunupyy",
     "wof:parent_id":1159321639,
     "wof:placetype":"localadmin",

--- a/data/907/199/673/907199673.geojson
+++ b/data/907/199/673/907199673.geojson
@@ -11,7 +11,7 @@
     "figov:national_code":"297",
     "figov:swe_type":"Kommun",
     "geom:area":0.661627,
-    "geom:area_square_m":3717290452.282805,
+    "geom:area_square_m":3717290452.282163,
     "geom:bbox":"26.890127759,62.5922636488,28.4579387479,63.403310726",
     "geom:latitude":62.975256,
     "geom:longitude":27.685645,
@@ -21,6 +21,9 @@
     ],
     "label:fin_x_preferred_placetype":[
         "kunta"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:swe_x_preferred_placetype":[
         "kommun"
@@ -242,15 +245,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "figov:code":"297",
+        "figov:id":"au1035403",
         "gn:id":650225,
         "gp:id":12590735,
         "qs_pg:id":81434
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
     ],
-    "wof:geomhash":"9c50e3cc66237365944c5e874a2ccbda",
+    "wof:geomhash":"b8f2b178c83022b41d1eae1646a21d6e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -263,7 +272,7 @@
         }
     ],
     "wof:id":907199673,
-    "wof:lastmodified":1582312099,
+    "wof:lastmodified":1695877714,
     "wof:name":"Kuopio",
     "wof:parent_id":1159321597,
     "wof:placetype":"localadmin",

--- a/data/907/199/697/907199697.geojson
+++ b/data/907/199/697/907199697.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -167,8 +170,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_295",
-        "eurostat:nuts_2021_id":"295"
+        "eurostat:nuts_2021_id":"295",
+        "figov:code":"295",
+        "figov:id":"au1039174"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"8252cfd1c0d8b1c55164e06371dae778",
     "wof:hierarchy":[
@@ -182,7 +191,7 @@
         }
     ],
     "wof:id":907199697,
-    "wof:lastmodified":1684352577,
+    "wof:lastmodified":1695877846,
     "wof:name":"Kumlinge",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/907/199/699/907199699.geojson
+++ b/data/907/199/699/907199699.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_139",
         "eurostat:nuts_2021_id":"139",
+        "figov:code":"139",
+        "figov:id":"au1040011",
         "gn:id":656852,
         "gp:id":12590837,
         "qs_pg:id":244411
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199699,
-    "wof:lastmodified":1684352577,
+    "wof:lastmodified":1695877846,
     "wof:name":"Ii",
     "wof:parent_id":1159321497,
     "wof:placetype":"localadmin",

--- a/data/907/199/705/907199705.geojson
+++ b/data/907/199/705/907199705.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -135,9 +138,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_748",
         "eurostat:nuts_2021_id":"748",
+        "figov:code":"748",
+        "figov:id":"au1040071",
         "gn:id":637003,
         "qs_pg:id":1029983
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -155,7 +164,7 @@
         }
     ],
     "wof:id":907199705,
-    "wof:lastmodified":1684352577,
+    "wof:lastmodified":1695877846,
     "wof:name":"Siikajoki",
     "wof:parent_id":1159321631,
     "wof:placetype":"localadmin",

--- a/data/907/199/707/907199707.geojson
+++ b/data/907/199/707/907199707.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -184,10 +187,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_915",
         "eurostat:nuts_2021_id":"915",
+        "figov:code":"915",
+        "figov:id":"au1042618",
         "gn:id":632371,
         "gp:id":12590748,
         "qs_pg:id":1029965
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -205,7 +214,7 @@
         }
     ],
     "wof:id":907199707,
-    "wof:lastmodified":1684352577,
+    "wof:lastmodified":1695877846,
     "wof:name":"Varkaus",
     "wof:parent_id":1159321629,
     "wof:placetype":"localadmin",

--- a/data/907/199/715/907199715.geojson
+++ b/data/907/199/715/907199715.geojson
@@ -11,7 +11,7 @@
     "figov:national_code":"91",
     "figov:swe_type":"Kommun",
     "geom:area":0.115491,
-    "geom:area_square_m":711578378.129991,
+    "geom:area_square_m":711578378.130012,
     "geom:bbox":"24.7828055478,59.9224932379,25.254496669,60.2978394089",
     "geom:latitude":60.113924,
     "geom:longitude":25.017104,
@@ -21,6 +21,9 @@
     ],
     "label:fin_x_preferred_placetype":[
         "kunta"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:swe_x_preferred_placetype":[
         "kommun"
@@ -587,10 +590,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "figov:code":"091",
+        "figov:id":"au1072577",
         "gn:id":658226,
         "gp:id":12590993,
         "qs_pg:id":1153729
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:coterminous":[
         101748417
     ],
@@ -598,7 +607,7 @@
     "wof:geom_alt":[
         "quattroshapes_pg"
     ],
-    "wof:geomhash":"8b23ff15d9f0131a5bb9b94b9dc0df41",
+    "wof:geomhash":"ddd1b23eca30988aaa8e18dbe531f5b1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -611,7 +620,7 @@
         }
     ],
     "wof:id":907199715,
-    "wof:lastmodified":1582312112,
+    "wof:lastmodified":1695877717,
     "wof:name":"Helsinki",
     "wof:parent_id":1159321633,
     "wof:placetype":"localadmin",

--- a/data/907/199/723/907199723.geojson
+++ b/data/907/199/723/907199723.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -165,9 +168,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_075",
         "eurostat:nuts_2021_id":"075",
+        "figov:code":"075",
+        "figov:id":"au1072639",
         "gp:id":12590755,
         "qs_pg:id":221605
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -185,7 +194,7 @@
         }
     ],
     "wof:id":907199723,
-    "wof:lastmodified":1684352578,
+    "wof:lastmodified":1695877847,
     "wof:name":"Hamina",
     "wof:parent_id":1159321573,
     "wof:placetype":"localadmin",

--- a/data/907/199/729/907199729.geojson
+++ b/data/907/199/729/907199729.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -66,8 +69,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"FI_478",
-        "eurostat:nuts_2021_id":"478"
+        "eurostat:nuts_2021_id":"478",
+        "figov:code":"478",
+        "figov:id":"au1073028"
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geomhash":"b4194f515e1154cb392e9eb3b0a36f41",
     "wof:hierarchy":[
@@ -81,7 +90,7 @@
         }
     ],
     "wof:id":907199729,
-    "wof:lastmodified":1684352578,
+    "wof:lastmodified":1695877848,
     "wof:name":"Maarianhamina",
     "wof:parent_id":85667871,
     "wof:placetype":"localadmin",

--- a/data/907/199/731/907199731.geojson
+++ b/data/907/199/731/907199731.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -192,9 +195,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_020",
         "eurostat:nuts_2021_id":"020",
+        "figov:code":"020",
+        "figov:id":"au23097819",
         "gn:id":8128757,
         "qs_pg:id":358248
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -212,7 +221,7 @@
         }
     ],
     "wof:id":907199731,
-    "wof:lastmodified":1684352578,
+    "wof:lastmodified":1695877848,
     "wof:name":"Akaa",
     "wof:parent_id":1159321621,
     "wof:placetype":"localadmin",

--- a/data/907/199/735/907199735.geojson
+++ b/data/907/199/735/907199735.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -84,10 +87,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_322",
         "eurostat:nuts_2021_id":"322",
+        "figov:code":"322",
+        "figov:id":"au24132280",
         "gn:id":652776,
         "gp:id":56071679,
         "qs_pg:id":26984
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":907199735,
-    "wof:lastmodified":1684352579,
+    "wof:lastmodified":1695877848,
     "wof:name":"Kemionsaari",
     "wof:parent_id":1159321605,
     "wof:placetype":"localadmin",

--- a/data/907/199/741/907199741.geojson
+++ b/data/907/199/741/907199741.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -93,9 +96,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_445",
         "eurostat:nuts_2021_id":"445",
+        "figov:code":"445",
+        "figov:id":"au24132281",
         "gn:id":642675,
         "qs_pg:id":1026793
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -113,7 +122,7 @@
         }
     ],
     "wof:id":907199741,
-    "wof:lastmodified":1684352579,
+    "wof:lastmodified":1695877848,
     "wof:name":"Parainen",
     "wof:parent_id":1159321605,
     "wof:placetype":"localadmin",

--- a/data/907/199/743/907199743.geojson
+++ b/data/907/199/743/907199743.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -75,10 +78,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_508",
         "eurostat:nuts_2021_id":"508",
+        "figov:code":"508",
+        "figov:id":"au24132282",
         "gn:id":8128761,
         "gp:id":56071675,
         "qs_pg:id":1042367
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":907199743,
-    "wof:lastmodified":1684352579,
+    "wof:lastmodified":1695877848,
     "wof:name":"Mantta-Vilppula",
     "wof:parent_id":1159321485,
     "wof:placetype":"localadmin",

--- a/data/907/199/747/907199747.geojson
+++ b/data/907/199/747/907199747.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,10 +75,16 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_710",
         "eurostat:nuts_2021_id":"710",
+        "figov:code":"710",
+        "figov:id":"au24132283",
         "gn:id":8128754,
         "gp:id":56071678,
         "qs_pg:id":1042365
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -93,7 +102,7 @@
         }
     ],
     "wof:id":907199747,
-    "wof:lastmodified":1684352579,
+    "wof:lastmodified":1695877849,
     "wof:name":"Raasepori",
     "wof:parent_id":1159321627,
     "wof:placetype":"localadmin",

--- a/data/907/199/751/907199751.geojson
+++ b/data/907/199/751/907199751.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -147,9 +150,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_790",
         "eurostat:nuts_2021_id":"790",
+        "figov:code":"790",
+        "figov:id":"au24132284",
         "gn:id":8128755,
         "qs_pg:id":358247
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -167,7 +176,7 @@
         }
     ],
     "wof:id":907199751,
-    "wof:lastmodified":1684352579,
+    "wof:lastmodified":1695877849,
     "wof:name":"Sastamala",
     "wof:parent_id":1159321613,
     "wof:placetype":"localadmin",

--- a/data/907/199/755/907199755.geojson
+++ b/data/907/199/755/907199755.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -126,9 +129,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_791",
         "eurostat:nuts_2021_id":"791",
+        "figov:code":"791",
+        "figov:id":"au24132285",
         "gn:id":8128756,
         "qs_pg:id":1155680
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -146,7 +155,7 @@
         }
     ],
     "wof:id":907199755,
-    "wof:lastmodified":1684352579,
+    "wof:lastmodified":1695877849,
     "wof:name":"Siikalatva",
     "wof:parent_id":1159321571,
     "wof:placetype":"localadmin",

--- a/data/907/199/763/907199763.geojson
+++ b/data/907/199/763/907199763.geojson
@@ -34,6 +34,9 @@
     "label:fin_x_preferred_placetype":[
         "kunta"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:swe_x_preferred_placetype":[
         "kommun"
     ],
@@ -72,9 +75,15 @@
     "wof:concordances":{
         "eg:gisco_id":"FI_946",
         "eurostat:nuts_2021_id":"946",
+        "figov:code":"946",
+        "figov:id":"au25175722",
         "gn:id":8128759,
         "qs_pg:id":1155675
     },
+    "wof:concordances_official":"figov:code",
+    "wof:concordances_official_alt":[
+        "figov:id"
+    ],
     "wof:country":"FI",
     "wof:geom_alt":[
         "quattroshapes_pg"
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":907199763,
-    "wof:lastmodified":1684352580,
+    "wof:lastmodified":1695877850,
     "wof:name":"Voyri",
     "wof:parent_id":1159321501,
     "wof:placetype":"localadmin",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.